### PR TITLE
feat: Draft work for decoupling of slot message from the client

### DIFF
--- a/src/bsgo/components/ComputerSlotComponent.cc
+++ b/src/bsgo/components/ComputerSlotComponent.cc
@@ -5,7 +5,8 @@ namespace bsgo {
 
 ComputerSlotComponent::ComputerSlotComponent(const PlayerComputer &computer)
   : SlotComponent(ComponentType::COMPUTER_SLOT,
-                  SlotComponentData{.offensive  = computer.offensive,
+                  SlotComponentData{.dbId       = computer.id,
+                                    .offensive  = computer.offensive,
                                     .powerCost  = computer.powerCost,
                                     .range      = computer.range,
                                     .reloadTime = computer.reloadTime})

--- a/src/bsgo/components/SlotComponent.cc
+++ b/src/bsgo/components/SlotComponent.cc
@@ -5,6 +5,7 @@ namespace bsgo {
 
 SlotComponent::SlotComponent(const ComponentType &type, const SlotComponentData &data)
   : AbstractComponent(type)
+  , m_dbId(data.dbId)
   , m_offensive(data.offensive)
   , m_powerCost(data.powerCost)
   , m_range(data.range)
@@ -16,6 +17,11 @@ SlotComponent::SlotComponent(const ComponentType &type, const SlotComponentData 
 void SlotComponent::update(const float elapsedSeconds)
 {
   handleReload(elapsedSeconds);
+}
+
+auto SlotComponent::dbId() const -> Uuid
+{
+  return m_dbId;
 }
 
 bool SlotComponent::isOffensive() const

--- a/src/bsgo/components/SlotComponent.hh
+++ b/src/bsgo/components/SlotComponent.hh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "AbstractComponent.hh"
+#include "Uuid.hh"
 #include <core_utils/TimeUtils.hh>
 #include <optional>
 
@@ -9,6 +10,7 @@ namespace bsgo {
 
 struct SlotComponentData
 {
+  Uuid dbId{};
   bool offensive{};
   float powerCost{};
   std::optional<float> range{};
@@ -33,6 +35,7 @@ class SlotComponent : public AbstractComponent
 
   void update(const float elapsedSeconds) override;
 
+  auto dbId() const -> Uuid;
   bool isOffensive() const;
   auto powerCost() const -> float;
   auto maybeRange() const -> std::optional<float>;
@@ -51,6 +54,7 @@ class SlotComponent : public AbstractComponent
   void clearFireRequest();
 
   private:
+  Uuid m_dbId{};
   bool m_offensive;
   float m_powerCost;
   std::optional<float> m_range;

--- a/src/bsgo/components/WeaponSlotComponent.cc
+++ b/src/bsgo/components/WeaponSlotComponent.cc
@@ -5,7 +5,8 @@ namespace bsgo {
 
 WeaponSlotComponent::WeaponSlotComponent(const PlayerWeapon &weapon, const Eigen::Vector3f &position)
   : SlotComponent(ComponentType::WEAPON_SLOT,
-                  SlotComponentData{.offensive  = true,
+                  SlotComponentData{.dbId       = weapon.id,
+                                    .offensive  = true,
                                     .powerCost  = weapon.powerCost,
                                     .range      = {weapon.range},
                                     .reloadTime = weapon.reloadTime})

--- a/src/bsgo/messages/ComponentUpdatedMessage.cc
+++ b/src/bsgo/messages/ComponentUpdatedMessage.cc
@@ -4,20 +4,27 @@
 namespace bsgo {
 
 ComponentUpdatedMessage::ComponentUpdatedMessage(const MessageType &type)
-  : ComponentUpdatedMessage(type, {}, {})
+  : ComponentUpdatedMessage(type, {}, {}, {})
 {}
 
 ComponentUpdatedMessage::ComponentUpdatedMessage(const MessageType &type,
-                                                 const Uuid entityId,
+                                                 const Uuid playerDbId,
+                                                 const Uuid shipDbId,
                                                  const ComponentType component)
   : NetworkMessage(type)
-  , m_entityId(entityId)
+  , m_playerDbId(playerDbId)
+  , m_shipDbId(shipDbId)
   , m_component(component)
 {}
 
-auto ComponentUpdatedMessage::getEntityId() const -> Uuid
+auto ComponentUpdatedMessage::getPlayerDbId() const -> Uuid
 {
-  return m_entityId;
+  return m_playerDbId;
+}
+
+auto ComponentUpdatedMessage::getShipDbId() const -> Uuid
+{
+  return m_shipDbId;
 }
 
 auto ComponentUpdatedMessage::getComponentType() const -> ComponentType

--- a/src/bsgo/messages/ComponentUpdatedMessage.hh
+++ b/src/bsgo/messages/ComponentUpdatedMessage.hh
@@ -11,15 +11,18 @@ class ComponentUpdatedMessage : public NetworkMessage
   public:
   ComponentUpdatedMessage(const MessageType &type);
   ComponentUpdatedMessage(const MessageType &type,
-                          const Uuid entityId,
+                          const Uuid playerDbId,
+                          const Uuid shipDbId,
                           const ComponentType component);
   ~ComponentUpdatedMessage() override = default;
 
-  auto getEntityId() const -> Uuid;
+  auto getPlayerDbId() const -> Uuid;
+  auto getShipDbId() const -> Uuid;
   auto getComponentType() const -> ComponentType;
 
   protected:
-  Uuid m_entityId{};
+  Uuid m_playerDbId{};
+  Uuid m_shipDbId{};
   ComponentType m_component{};
 };
 

--- a/src/bsgo/messages/SlotComponentMessage.cc
+++ b/src/bsgo/messages/SlotComponentMessage.cc
@@ -8,19 +8,20 @@ SlotComponentMessage::SlotComponentMessage()
   : ComponentUpdatedMessage(MessageType::SLOT_COMPONENT_UPDATED)
 {}
 
-SlotComponentMessage::SlotComponentMessage(const Uuid entityId,
-                                           const int slotIndex,
+SlotComponentMessage::SlotComponentMessage(const Uuid playerDbId,
+                                           const Uuid shipDbId,
                                            const SlotComponent &component)
-  : ComponentUpdatedMessage(MessageType::SLOT_COMPONENT_UPDATED, entityId, component.type())
-  , m_slotIndex(slotIndex)
-  , m_fireRequest(component.hasFireRequest())
-  , m_firingState(component.firingState())
+  : ComponentUpdatedMessage(MessageType::SLOT_COMPONENT_UPDATED,
+                            playerDbId,
+                            shipDbId,
+                            component.type())
+  , m_slotDbId(component.dbId())
   , m_elapsedSinceLastFired(component.elapsedSinceLastFired())
 {}
 
-auto SlotComponentMessage::getSlotIndex() const -> int
+auto SlotComponentMessage::getSlotDbId() const -> int
 {
-  return m_slotIndex;
+  return m_slotDbId;
 }
 
 auto SlotComponentMessage::getElapsedSinceLastFired() const -> std::optional<utils::Duration>
@@ -33,11 +34,10 @@ auto SlotComponentMessage::serialize(std::ostream &out) const -> std::ostream &
   utils::serialize(out, m_messageType);
   utils::serialize(out, m_clientId);
 
-  utils::serialize(out, m_entityId);
+  utils::serialize(out, m_playerDbId);
+  utils::serialize(out, m_shipDbId);
   utils::serialize(out, m_component);
-  utils::serialize(out, m_slotIndex);
-  utils::serialize(out, m_fireRequest);
-  utils::serialize(out, m_firingState);
+  utils::serialize(out, m_slotDbId);
   utils::serialize(out, m_elapsedSinceLastFired);
 
   return out;
@@ -49,11 +49,10 @@ bool SlotComponentMessage::deserialize(std::istream &in)
   ok &= utils::deserialize(in, m_messageType);
   ok &= utils::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_entityId);
+  ok &= utils::deserialize(in, m_playerDbId);
+  ok &= utils::deserialize(in, m_shipDbId);
   ok &= utils::deserialize(in, m_component);
-  ok &= utils::deserialize(in, m_slotIndex);
-  ok &= utils::deserialize(in, m_fireRequest);
-  ok &= utils::deserialize(in, m_firingState);
+  ok &= utils::deserialize(in, m_slotDbId);
   ok &= utils::deserialize(in, m_elapsedSinceLastFired);
 
   return ok;

--- a/src/bsgo/messages/SlotComponentMessage.hh
+++ b/src/bsgo/messages/SlotComponentMessage.hh
@@ -10,20 +10,18 @@ class SlotComponentMessage : public ComponentUpdatedMessage
 {
   public:
   SlotComponentMessage();
-  SlotComponentMessage(const Uuid entityId, const int slotIndex, const SlotComponent &component);
+  SlotComponentMessage(const Uuid playerDbId, const Uuid shipDbId, const SlotComponent &component);
   ~SlotComponentMessage() override = default;
 
-  auto getSlotIndex() const -> int;
+  auto getSlotDbId() const -> Uuid;
   auto getElapsedSinceLastFired() const -> std::optional<utils::Duration>;
 
   auto serialize(std::ostream &out) const -> std::ostream & override;
   bool deserialize(std::istream &in) override;
 
   private:
-  int m_slotIndex{};
+  Uuid m_slotDbId{};
 
-  bool m_fireRequest{false};
-  FiringState m_firingState{FiringState::READY};
   std::optional<utils::Duration> m_elapsedSinceLastFired{};
 };
 

--- a/src/bsgo/systems/ComputerSystem.cc
+++ b/src/bsgo/systems/ComputerSystem.cc
@@ -34,16 +34,14 @@ void ComputerSystem::updateEntity(Entity &entity,
     targetEnt = coordinator.getEntity(*target);
   }
 
-  const auto count = static_cast<int>(entity.computers.size());
-  for (auto id = 0; id < count; ++id)
+  for (const auto &computer : entity.computers)
   {
-    const auto &computer = entity.computers[id];
     updateComputer(entity, computer, targetEnt, elapsedSeconds);
     if (computer->hasFireRequest())
     {
       if (processFireRequest(entity, computer, targetEnt, coordinator))
       {
-        sendComponentUpdatedMessage(entity, id, *computer, coordinator);
+        sendComponentUpdatedMessage(entity, *computer, coordinator);
       }
     }
   }
@@ -133,24 +131,21 @@ void ComputerSystem::applyReceiverEffects(Entity &target,
 }
 
 void ComputerSystem::sendComponentUpdatedMessage(const Entity &entity,
-                                                 const int slotIndex,
                                                  const SlotComponent &component,
-                                                 const Coordinator & /*coordinator*/) const
+                                                 const Coordinator &coordinator) const
 {
-  /// TODO: Use the player db id to find some sort of client id
-  // std::optional<Uuid> playerDbId{};
-  // if (entity.exists<OwnerComponent>())
-  // {
-  //   const auto ownerEntityId = entity.ownerComp().owner();
-  //   const auto player        = coordinator.getEntity(ownerEntityId);
+  if (!entity.exists<OwnerComponent>())
+  {
+    return;
+  }
 
-  //   if (player.exists<DbComponent>())
-  //   {
-  //     playerDbId = player.dbComp().dbId();
-  //   }
-  // }
+  const auto ownerEntityId = entity.ownerComp().owner();
+  const auto player        = coordinator.getEntity(ownerEntityId);
 
-  pushMessage(std::make_unique<SlotComponentMessage>(entity.uuid, slotIndex, component));
+  const auto shipDbId   = entity.dbComp().dbId();
+  const auto playerDbId = player.dbComp().dbId();
+
+  pushMessage(std::make_unique<SlotComponentMessage>(playerDbId, shipDbId, component));
 }
 
 } // namespace bsgo

--- a/src/bsgo/systems/ComputerSystem.hh
+++ b/src/bsgo/systems/ComputerSystem.hh
@@ -33,7 +33,6 @@ class ComputerSystem : public AbstractSystem
                             Coordinator &coordinator) const;
 
   void sendComponentUpdatedMessage(const Entity &entity,
-                                   const int slotIndex,
                                    const SlotComponent &component,
                                    const Coordinator &coordinator) const;
 };

--- a/src/client/lib/App.cc
+++ b/src/client/lib/App.cc
@@ -45,7 +45,7 @@ void App::loadResources(const Vec2i &screenDims, Renderer &engine)
   m_game->generateInputHandlers();
   m_game->generateUiHandlers(screenDims.x, screenDims.y);
 
-#define START_AT_LOGIN
+// #define START_AT_LOGIN
 #ifndef START_AT_LOGIN
   m_game->login(bsgo::Uuid{0});
   m_game->setScreen(Screen::GAME);

--- a/src/client/lib/consumers/SlotComponentMessageConsumer.cc
+++ b/src/client/lib/consumers/SlotComponentMessageConsumer.cc
@@ -36,16 +36,19 @@ void SlotComponentMessageConsumer::onMessageReceived(const bsgo::IMessage &messa
 void SlotComponentMessageConsumer::handleComputerSlotUpdated(
   const bsgo::SlotComponentMessage &message) const
 {
-  const auto entityId   = message.getEntityId();
-  const auto computerId = message.getSlotIndex();
+  /// TODO: Should find the entity associated to the player and handle the update.
+  warn("should handle computer updated for " + bsgo::str(message.getPlayerDbId()) + " on ship "
+       + bsgo::str(message.getShipDbId()) + " for slot " + bsgo::str(message.getSlotDbId()));
+  // const auto entityId   = message.getEntityId();
+  // const auto computerId = message.getSlotIndex();
 
-  const bsgo::SlotService::SlotUpdateData data{
-    .elapsedSinceLastFired = message.getElapsedSinceLastFired()};
+  // const bsgo::SlotService::SlotUpdateData data{
+  //   .elapsedSinceLastFired = message.getElapsedSinceLastFired()};
 
-  if (!m_slotService->trySyncComputer(entityId, computerId, data))
-  {
-    warn("Failed to process computer component updated message for entity " + bsgo::str(entityId));
-  }
+  // if (!m_slotService->trySyncComputer(entityId, computerId, data))
+  // {
+  //   warn("Failed to process computer component updated message for entity " + bsgo::str(entityId));
+  // }
 }
 
 } // namespace pge

--- a/src/client/lib/ui/game/LogUiHandler.cc
+++ b/src/client/lib/ui/game/LogUiHandler.cc
@@ -93,6 +93,19 @@ constexpr std::size_t MAXIMUM_NUMBER_OF_LOGS_DISPLAYED = 5;
 const Vec2i LOG_MENU_DIMS{150, 20};
 constexpr auto LOG_FADE_OUT_DURATION_MS = 7000;
 
+bool checkComputerIsOffensive(const bsgo::Entity &playerShip, const bsgo::Uuid computerDbId)
+{
+  for (const auto &computer : playerShip.computers)
+  {
+    if (computer->dbId() == computerDbId)
+    {
+      return computer->isOffensive();
+    }
+  }
+
+  return false;
+}
+
 bool shouldMessageBeFiltered(const bsgo::IMessage &message, const bsgo::Entity &playerShip)
 {
   if (bsgo::MessageType::JUMP_CANCELLED == message.type())
@@ -115,9 +128,7 @@ bool shouldMessageBeFiltered(const bsgo::IMessage &message, const bsgo::Entity &
       return true;
     }
 
-    const auto computerIsOffensive = playerShip.computers.at(slotMessage.getSlotIndex())
-                                       ->isOffensive();
-    return computerIsOffensive;
+    return checkComputerIsOffensive(playerShip, slotMessage.getSlotDbId());
   }
 
   return false;

--- a/src/server/lib/clients/LoginCallback.hh
+++ b/src/server/lib/clients/LoginCallback.hh
@@ -1,0 +1,15 @@
+
+#pragma once
+
+#include "Uuid.hh"
+#include <functional>
+
+namespace bsgo {
+
+/// @brief - Callback for when a player has successfully logged in.
+/// @param clientId - the index of the client which just logged in: this is passed with
+/// the messages received from this client.
+/// @param playerDbId - the index of the player in the database associated to the client.
+using PlayerLoginCallback = std::function<void(const Uuid clientId, const Uuid playerDbId)>;
+
+} // namespace bsgo

--- a/src/server/lib/consumers/LoginMessageConsumer.cc
+++ b/src/server/lib/consumers/LoginMessageConsumer.cc
@@ -4,10 +4,12 @@
 namespace bsgo {
 
 LoginMessageConsumer::LoginMessageConsumer(const Services &services,
-                                           IMessageQueue *const messageQueue)
+                                           IMessageQueue *const messageQueue,
+                                           const PlayerLoginCallback &playerLoginCallback)
   : AbstractMessageConsumer("login", {MessageType::LOGIN})
   , m_loginService(services.login)
   , m_messageQueue(messageQueue)
+  , m_playerLoginCallback(playerLoginCallback)
 {
   if (nullptr == m_loginService)
   {
@@ -40,6 +42,8 @@ void LoginMessageConsumer::handleLogin(const LoginMessage &message) const
   {
     warn("Failed to process login message for player " + name);
   }
+
+  m_playerLoginCallback(message.getClientId(), *playerDbId);
 
   auto out = std::make_unique<LoginMessage>(name, password, playerDbId);
   out->validate();

--- a/src/server/lib/consumers/LoginMessageConsumer.hh
+++ b/src/server/lib/consumers/LoginMessageConsumer.hh
@@ -3,6 +3,7 @@
 
 #include "AbstractMessageConsumer.hh"
 #include "IMessageQueue.hh"
+#include "LoginCallback.hh"
 #include "LoginMessage.hh"
 #include "Services.hh"
 
@@ -11,7 +12,9 @@ namespace bsgo {
 class LoginMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  LoginMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  LoginMessageConsumer(const Services &services,
+                       IMessageQueue *const messageQueue,
+                       const PlayerLoginCallback &playerLoginCallback);
   ~LoginMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -19,6 +22,7 @@ class LoginMessageConsumer : public AbstractMessageConsumer
   private:
   LoginServiceShPtr m_loginService{};
   IMessageQueue *const m_messageQueue{};
+  PlayerLoginCallback m_playerLoginCallback{};
 
   void handleLogin(const LoginMessage &message) const;
 };

--- a/src/server/lib/consumers/ServerMessageConsumerUtils.cc
+++ b/src/server/lib/consumers/ServerMessageConsumerUtils.cc
@@ -14,39 +14,39 @@
 
 namespace bsgo {
 
-void createMessageConsumers(IMessageQueue &inputMessagesQueue,
-                            IMessageQueue *const outputMessagesQueue,
-                            const Services &services)
+void createMessageConsumers(const ConsumersConfig &config)
 {
-  inputMessagesQueue.addListener(
-    std::make_unique<SignupMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<SignupMessageConsumer>(config.services, config.outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<LoginMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<LoginMessageConsumer>(config.services,
+                                           config.outputMessagesQueue,
+                                           config.loginCallback));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<HangarMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<HangarMessageConsumer>(config.services, config.outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<PurchaseMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<PurchaseMessageConsumer>(config.services, config.outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<EquipMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<EquipMessageConsumer>(config.services, config.outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<DockMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<DockMessageConsumer>(config.services, config.outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<SlotMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<SlotMessageConsumer>(config.services, config.outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<JumpMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<JumpMessageConsumer>(config.services, config.outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<JumpCancelledMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<JumpCancelledMessageConsumer>(config.services, config.outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<JumpRequestedMessageConsumer>(services, outputMessagesQueue));
+  config.inputMessagesQueue.addListener(
+    std::make_unique<JumpRequestedMessageConsumer>(config.services, config.outputMessagesQueue));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/ServerMessageConsumerUtils.hh
+++ b/src/server/lib/consumers/ServerMessageConsumerUtils.hh
@@ -3,12 +3,19 @@
 
 #include "IMessageListener.hh"
 #include "IMessageQueue.hh"
+#include "LoginCallback.hh"
 #include "Services.hh"
 
 namespace bsgo {
 
-void createMessageConsumers(IMessageQueue &inputMessagesQueue,
-                            IMessageQueue *const outputMessagesQueue,
-                            const Services &services);
+struct ConsumersConfig
+{
+  IMessageQueue &inputMessagesQueue;
+  IMessageQueue *const outputMessagesQueue{};
+  Services services{};
+  PlayerLoginCallback loginCallback{};
+};
 
-}
+void createMessageConsumers(const ConsumersConfig &config);
+
+} // namespace bsgo

--- a/src/server/lib/game/SystemProcessor.cc
+++ b/src/server/lib/game/SystemProcessor.cc
@@ -44,7 +44,12 @@ void SystemProcessor::initialize(const SystemProcessingConfig &config)
   m_coordinator = std::make_shared<Coordinator>(std::move(networkSystem), config.outputMessageQueue);
 
   m_services = createServices(repositories, m_coordinator);
-  createMessageConsumers(*config.inputMessageQueue, config.outputMessageQueue, m_services);
+
+  const ConsumersConfig consumersConfig{.inputMessagesQueue  = *config.inputMessageQueue,
+                                        .outputMessagesQueue = config.outputMessageQueue,
+                                        .services            = m_services,
+                                        .loginCallback       = config.playerLoginCallback};
+  createMessageConsumers(consumersConfig);
 
   dataSource.setSystemDbId(config.systemDbId);
   dataSource.initialize(*m_coordinator);

--- a/src/server/lib/game/SystemProcessor.hh
+++ b/src/server/lib/game/SystemProcessor.hh
@@ -3,6 +3,7 @@
 
 #include "Coordinator.hh"
 #include "IMessageQueue.hh"
+#include "LoginCallback.hh"
 #include "Services.hh"
 #include "Uuid.hh"
 #include <atomic>
@@ -17,6 +18,7 @@ struct SystemProcessingConfig
   Uuid systemDbId{};
   IMessageQueue *const inputMessageQueue{};
   IMessageQueue *const outputMessageQueue{};
+  PlayerLoginCallback playerLoginCallback{};
 };
 
 class SystemProcessor : public utils::CoreObject

--- a/src/server/lib/queues/BroadcastMessageQueue.cc
+++ b/src/server/lib/queues/BroadcastMessageQueue.cc
@@ -2,6 +2,7 @@
 #include "BroadcastMessageQueue.hh"
 #include "MessageProcessor.hh"
 #include "NetworkMessage.hh"
+#include "SlotComponentMessage.hh"
 
 namespace bsgo {
 
@@ -20,6 +21,17 @@ void BroadcastMessageQueue::registerClient(const Uuid clientId, net::ConnectionS
   if (!inserted)
   {
     error("Failed to register client " + str(clientId), "Such a client already exists");
+  }
+}
+
+void BroadcastMessageQueue::registerPlayer(const Uuid clientId, const Uuid playerDbId)
+{
+  const std::lock_guard guard(m_locker);
+
+  const auto [_, inserted] = m_playerDbIdToClientId.try_emplace(playerDbId, clientId);
+  if (!inserted)
+  {
+    error("Failed to register player " + str(playerDbId), "Already logged in with another client");
   }
 }
 
@@ -56,8 +68,13 @@ void BroadcastMessageQueue::processMessage(const IMessage &message)
     error("Unsupported message type " + str(message.type()), "Message is not a network message");
   }
 
-  const auto &network      = message.as<NetworkMessage>();
-  const auto maybeClientId = network.tryGetClientId();
+  const auto &network = message.as<NetworkMessage>();
+  auto maybeClientId  = network.tryGetClientId();
+  if (!maybeClientId)
+  {
+    maybeClientId = tryDetermineClientIdFromMessage(message);
+  }
+
   if (maybeClientId)
   {
     sendMessageToClient(*maybeClientId, message);
@@ -66,6 +83,35 @@ void BroadcastMessageQueue::processMessage(const IMessage &message)
   {
     broadcastMessage(message);
   }
+}
+
+namespace {
+auto tryDeterminePlayerDbId(const SlotComponentMessage &message,
+                            const std::unordered_map<Uuid, Uuid> &playersToClients) -> Uuid
+{
+  const auto playerDbId    = message.getPlayerDbId();
+  const auto maybeClientId = playersToClients.find(playerDbId);
+
+  if (maybeClientId == playersToClients.cend())
+  {
+    return {};
+  }
+  return maybeClientId->second;
+}
+} // namespace
+
+auto BroadcastMessageQueue::tryDetermineClientIdFromMessage(const IMessage &message)
+  -> std::optional<Uuid>
+{
+  switch (message.type())
+  {
+    case MessageType::SLOT_COMPONENT_UPDATED:
+      return tryDeterminePlayerDbId(message.as<SlotComponentMessage>(), m_playerDbIdToClientId);
+    default:
+      break;
+  }
+  warn("should try to determine client id from " + str(message.type()));
+  return {};
 }
 
 void BroadcastMessageQueue::sendMessageToClient(const Uuid clientId, const IMessage &message)

--- a/src/server/lib/queues/BroadcastMessageQueue.hh
+++ b/src/server/lib/queues/BroadcastMessageQueue.hh
@@ -19,6 +19,7 @@ class BroadcastMessageQueue : public IMessageQueue, public utils::CoreObject
   ~BroadcastMessageQueue() override = default;
 
   void registerClient(const Uuid clientId, net::ConnectionShPtr connection);
+  void registerPlayer(const Uuid clientId, const Uuid playerDbId);
 
   void pushMessage(IMessagePtr message) override;
   void addListener(IMessageListenerPtr listener) override;
@@ -30,9 +31,11 @@ class BroadcastMessageQueue : public IMessageQueue, public utils::CoreObject
   std::mutex m_locker{};
   std::deque<IMessagePtr> m_messages{};
   std::unordered_map<Uuid, net::ConnectionShPtr> m_clients{};
+  std::unordered_map<Uuid, Uuid> m_playerDbIdToClientId{};
 
   void processMessage(const IMessage &message);
 
+  auto tryDetermineClientIdFromMessage(const IMessage &message) -> std::optional<Uuid>;
   void sendMessageToClient(const Uuid clientId, const IMessage &message);
   void broadcastMessage(const IMessage &message);
 };


### PR DESCRIPTION
# Work
Second attempt at decoupling slot message from the client. This builds up on #1 but also does not work.

# Progress
* When a client successfully logs in we register it with the index of its connection.
* The `BroadcastMessageQueue` attempts to determine the client id when possible.

# What does not work
When registering multiple systems we have no way to control which `SystemProcessor` will process messages which lead to inconsistencies with entity ids.

# How was it solved

The idea was to have a message dispatcher which takes the input messages and try to route them internally in the server to where they belongs:
* we have a queue for system messages (i.e. messages which are no linked to any system or entity such as login and signup)
* one internal queue per system supposed to process only messages relevant to this system (typically the dock/undock messages and entity added/removed)

The ground work was laid out (among other commits) in [23b4a8b](https://github.com/Knoblauchpilze/bsgalone/commit/23b4a8b3635a28ae0c1d6b32b955ad83275688bc).

With this approach we are able to make sure that each message is processed by a system which can interpret it.