### PR TITLE
feat: Segfault debug

### DIFF
--- a/src/bsgo/components/NetworkComponent.cc
+++ b/src/bsgo/components/NetworkComponent.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 namespace {
-constexpr auto BASE_SYNC_INTERVAL_MS = 1000;
+constexpr auto BASE_SYNC_INTERVAL_MS = 500;
 constexpr auto MAX_SYNC_JITTER_MS    = 100;
 
 auto generateJitteredSyncInterval() -> utils::Duration

--- a/src/bsgo/controller/Coordinator.cc
+++ b/src/bsgo/controller/Coordinator.cc
@@ -434,6 +434,7 @@ void Coordinator::cleanUpDeadEntities()
     const auto ent = getEntity(id);
     if (ent.exists<RemovalComponent>() && ent.removalComp().toBeDeleted())
     {
+      debug("marking " + ent.str() + " for removal");
       deletedEntities.insert(id);
     }
   }

--- a/src/bsgo/queues/AsyncMessageQueue.cc
+++ b/src/bsgo/queues/AsyncMessageQueue.cc
@@ -3,8 +3,8 @@
 
 namespace bsgo {
 
-AsyncMessageQueue::AsyncMessageQueue(IMessageQueuePtr messageQueue)
-  : utils::CoreObject("async")
+AsyncMessageQueue::AsyncMessageQueue(const std::string &name, IMessageQueuePtr messageQueue)
+  : utils::CoreObject(name)
   , m_messageQueue(std::move(messageQueue))
 {
   addModule("queue");
@@ -25,14 +25,17 @@ AsyncMessageQueue::~AsyncMessageQueue()
     return;
   }
 
-  m_running.store(false);
+  debug("requesting stop on async message queue");
   {
     std::unique_lock lock(m_messageLocker);
+    m_running.store(false);
     m_messageNotifier.notify_one();
   }
   if (m_queueThread.joinable())
   {
+    debug("waiting for thread");
     m_queueThread.join();
+    debug("finished waiting for thread");
   }
 }
 

--- a/src/bsgo/queues/AsyncMessageQueue.cc
+++ b/src/bsgo/queues/AsyncMessageQueue.cc
@@ -75,10 +75,13 @@ void AsyncMessageQueue::asyncMessageProcessing()
     m_messageNotifier.wait(lock, [this] { return !m_running.load() || !m_messageQueue->empty(); });
 
     running = m_running.load();
+    debug("checking for message processing: " + std::to_string(running));
     if (running)
     {
       constexpr auto MESSAGES_BATCH_SIZE = 10;
+      debug("calling on internal message queue");
       m_messageQueue->processMessages(MESSAGES_BATCH_SIZE);
+      debug("processed messages on internal queue");
     }
   }
 

--- a/src/bsgo/queues/AsyncMessageQueue.hh
+++ b/src/bsgo/queues/AsyncMessageQueue.hh
@@ -12,7 +12,7 @@ namespace bsgo {
 class AsyncMessageQueue : public IMessageQueue, public utils::CoreObject
 {
   public:
-  AsyncMessageQueue(IMessageQueuePtr messageQueue);
+  AsyncMessageQueue(const std::string &name, IMessageQueuePtr messageQueue);
   ~AsyncMessageQueue() override;
 
   void pushMessage(IMessagePtr message) override;

--- a/src/bsgo/queues/MessageProcessor.cc
+++ b/src/bsgo/queues/MessageProcessor.cc
@@ -84,8 +84,8 @@ void MessageProcessor::processMessages(const std::string &name, const std::optio
     }
     else
     {
-      verbose(name + " Processed " + std::to_string(count) + "/" + std::to_string(messages.size())
-              + " message(s): " + messagesInfo.messagesTypes);
+      debug(name + " Processed " + std::to_string(count) + "/" + std::to_string(messages.size())
+            + " message(s): " + messagesInfo.messagesTypes);
     }
     messages.erase(messages.begin(), messages.begin() + count);
   }
@@ -103,7 +103,7 @@ auto MessageProcessor::acquireAndClearMessages() -> std::deque<IMessagePtr>
 
 void MessageProcessor::requeueMessages(std::deque<IMessagePtr> &&messages)
 {
-  verbose("Requeuing " + std::to_string(messages.size()) + " message(s)");
+  debug("Requeuing " + std::to_string(messages.size()) + " message(s)");
 
   const std::lock_guard guard(m_locker);
   // https://stackoverflow.com/questions/35844999/move-stdvector-to-stddeque-in-c11

--- a/src/bsgo/queues/MessageProcessor.cc
+++ b/src/bsgo/queues/MessageProcessor.cc
@@ -62,7 +62,7 @@ auto messagesTypesToString(const std::deque<IMessagePtr> &messages, const int co
 }
 } // namespace
 
-void MessageProcessor::processMessages(const std::optional<int> &amount)
+void MessageProcessor::processMessages(const std::string &name, const std::optional<int> &amount)
 {
   auto messages            = acquireAndClearMessages();
   const auto messagesCount = static_cast<int>(messages.size());
@@ -79,12 +79,12 @@ void MessageProcessor::processMessages(const std::optional<int> &amount)
     const auto messagesInfo = messagesTypesToString(messages, count);
     if (messagesInfo.importantMessagesCount > 0)
     {
-      info("Processed " + std::to_string(count) + "/" + std::to_string(messages.size())
+      info(name + " Processed " + std::to_string(count) + "/" + std::to_string(messages.size())
            + " message(s): " + messagesInfo.messagesTypes);
     }
     else
     {
-      verbose("Processed " + std::to_string(count) + "/" + std::to_string(messages.size())
+      verbose(name + " Processed " + std::to_string(count) + "/" + std::to_string(messages.size())
               + " message(s): " + messagesInfo.messagesTypes);
     }
     messages.erase(messages.begin(), messages.begin() + count);

--- a/src/bsgo/queues/MessageProcessor.hh
+++ b/src/bsgo/queues/MessageProcessor.hh
@@ -17,7 +17,7 @@ class MessageProcessor : public utils::CoreObject
   public:
   MessageProcessor(std::deque<IMessagePtr> &messages, std::mutex &locker, MessageHandler handler);
 
-  void processMessages(const std::optional<int> &amount);
+  void processMessages(const std::string &name, const std::optional<int> &amount);
 
   private:
   std::mutex &m_locker;

--- a/src/bsgo/queues/NetworkMessageQueue.cc
+++ b/src/bsgo/queues/NetworkMessageQueue.cc
@@ -1,7 +1,6 @@
 
 #include "NetworkMessageQueue.hh"
 #include "MessageParser.hh"
-#include "SynchronizedMessageQueue.hh"
 
 namespace bsgo {
 

--- a/src/bsgo/queues/SynchronizedMessageQueue.cc
+++ b/src/bsgo/queues/SynchronizedMessageQueue.cc
@@ -2,14 +2,16 @@
 #include "SynchronizedMessageQueue.hh"
 #include "MessageProcessor.hh"
 
+#include <iostream>
+
 namespace bsgo {
 
-SynchronizedMessageQueue::SynchronizedMessageQueue()
+SynchronizedMessageQueue::SynchronizedMessageQueue(const std::string &name)
   : AbstractMessageQueue()
-  , utils::CoreObject("synchronized")
+  , utils::CoreObject(name)
 {
-  addModule("queue");
   setService("message");
+  addModule("queue");
 }
 
 void SynchronizedMessageQueue::pushMessage(IMessagePtr message)
@@ -32,11 +34,13 @@ bool SynchronizedMessageQueue::empty()
 
 void SynchronizedMessageQueue::processMessages(const std::optional<int> &amount)
 {
+  std::cout << getName() << " processing messages" << std::endl;
   MessageProcessor processor(m_messages, m_locker, [this](const IMessage &message) {
     processMessage(message);
   });
 
-  processor.processMessages(amount);
+  processor.processMessages(getName(), amount);
+  std::cout << getName() << " processed messages" << std::endl;
 }
 
 void SynchronizedMessageQueue::processMessage(const IMessage &message) const

--- a/src/bsgo/queues/SynchronizedMessageQueue.hh
+++ b/src/bsgo/queues/SynchronizedMessageQueue.hh
@@ -13,7 +13,7 @@ namespace bsgo {
 class SynchronizedMessageQueue : public AbstractMessageQueue, public utils::CoreObject
 {
   public:
-  SynchronizedMessageQueue();
+  SynchronizedMessageQueue(const std::string &name);
   ~SynchronizedMessageQueue() override = default;
 
   void pushMessage(IMessagePtr message) override;

--- a/src/bsgo/systems/AbstractSystem.cc
+++ b/src/bsgo/systems/AbstractSystem.cc
@@ -66,6 +66,7 @@ void AbstractSystem::pushInternalMessage(IMessagePtr message) const
 {
   if (m_internalMessageQueue != nullptr)
   {
+    debug("pushing message " + str(message->type()));
     m_internalMessageQueue->pushMessage(std::move(message));
   }
 }

--- a/src/client/lib/game/Game.cc
+++ b/src/client/lib/game/Game.cc
@@ -335,7 +335,7 @@ void Game::initialize()
   m_inputMessageQueue = connection->createInputMessageQueue();
   // Not strictly necessary as the internal messages should only be produced
   // synchronously by the Coordinator but also does not hurt.
-  m_internalMessageQueue = std::make_unique<bsgo::SynchronizedMessageQueue>();
+  m_internalMessageQueue = std::make_unique<bsgo::SynchronizedMessageQueue>("internal");
   m_outputMessageQueue   = std::make_unique<ClientMessageQueue>(std::move(connection));
 
   const auto repositories = m_dataSource.repositories();

--- a/src/client/lib/network/ClientConnection.cc
+++ b/src/client/lib/network/ClientConnection.cc
@@ -27,7 +27,7 @@ void ClientConnection::sendMessage(const bsgo::IMessage &message)
 
 auto ClientConnection::createInputMessageQueue() -> bsgo::IMessageQueuePtr
 {
-  auto synchronizedQueue = std::make_unique<bsgo::SynchronizedMessageQueue>();
+  auto synchronizedQueue = std::make_unique<bsgo::SynchronizedMessageQueue>("input");
   auto queue = std::make_unique<bsgo::NetworkMessageQueue>(std::move(synchronizedQueue));
   queue->registerToConnection(*m_connection);
   return queue;

--- a/src/net/connection/Connection.cc
+++ b/src/net/connection/Connection.cc
@@ -180,6 +180,7 @@ void Connection::onDataReceived(const std::error_code &code, const std::size_t c
               std::begin(m_incomingDataTempBuffer) + contentLength,
               std::back_inserter(m_partialMessageData));
 
+    debug("calling data");
     const auto processed = (*m_dataHandler)(m_id, m_partialMessageData);
     m_partialMessageData.erase(m_partialMessageData.begin(),
                                m_partialMessageData.begin() + processed);

--- a/src/net/connection/Context.cc
+++ b/src/net/connection/Context.cc
@@ -30,7 +30,10 @@ void Context::start()
   }
 
   m_running.store(true);
-  m_contextThread = std::thread([this]() { m_asioContext.run(); });
+  m_contextThread = std::thread([this]() {
+    m_asioContext.run();
+    debug("haha");
+  });
 
   debug("Successfully started asio context");
 }

--- a/src/server/lib/Server.hh
+++ b/src/server/lib/Server.hh
@@ -18,7 +18,7 @@ class Server : public utils::CoreObject
 {
   public:
   Server();
-  ~Server() override = default;
+  ~Server() override;
 
   void run(const int port);
   void requestStop();

--- a/src/server/lib/game/MessageExchanger.cc
+++ b/src/server/lib/game/MessageExchanger.cc
@@ -15,12 +15,24 @@
 #include "SynchronizedMessageQueue.hh"
 #include "TriageMessageConsumer.hh"
 
+#include <iostream>
+
 namespace bsgo {
 
 MessageExchanger::MessageExchanger(const MessageSystemData &messagesData)
 {
   initialize(messagesData);
 }
+
+// MessageExchanger::~MessageExchanger()
+// {
+//   m_inputMessageQueue.reset();
+//   std::cout << "reset internal msg queue" << std::endl;
+//   m_internalMessageQueue.reset();
+//   std::cout << "reset output msg queue" << std::endl;
+//   m_outputMessageQueue.reset();
+//   std::cout << "reset all queues" << std::endl;
+// }
 
 auto MessageExchanger::getInternalMessageQueue() const -> IMessageQueue *
 {
@@ -49,7 +61,7 @@ void MessageExchanger::pushMessage(IMessagePtr message)
 namespace {
 auto createInputMessageQueue() -> NetworkMessageQueuePtr
 {
-  auto messageQueue = std::make_unique<SynchronizedMessageQueue>();
+  auto messageQueue = std::make_unique<SynchronizedMessageQueue>("input-msg");
   auto asyncQueue   = std::make_unique<AsyncMessageQueue>(std::move(messageQueue));
 
   return std::make_unique<NetworkMessageQueue>(std::move(asyncQueue));
@@ -57,7 +69,7 @@ auto createInputMessageQueue() -> NetworkMessageQueuePtr
 
 auto createInternalMessageQueue() -> IMessageQueuePtr
 {
-  auto messageQueue = std::make_unique<SynchronizedMessageQueue>();
+  auto messageQueue = std::make_unique<SynchronizedMessageQueue>("internal-msg");
   return std::make_unique<AsyncMessageQueue>(std::move(messageQueue));
 }
 
@@ -85,7 +97,7 @@ void MessageExchanger::initialize(const MessageSystemData &messagesData)
 namespace {
 auto createSystemMessageQueue() -> IMessageQueuePtr
 {
-  auto systemQueue = std::make_unique<SynchronizedMessageQueue>();
+  auto systemQueue = std::make_unique<SynchronizedMessageQueue>("system-msg");
   return std::make_unique<AsyncMessageQueue>(std::move(systemQueue));
 }
 } // namespace
@@ -122,8 +134,8 @@ void MessageExchanger::initializeInternalConsumers(const MessageSystemData &mess
   Repositories repositories{};
   auto systemService = std::make_shared<SystemService>(std::move(repositories));
 
-  m_internalMessageQueue->addListener(
-    std::make_unique<LootMessageConsumer>(systemService, m_outputMessageQueue.get()));
+  // m_internalMessageQueue->addListener(
+  //   std::make_unique<LootMessageConsumer>(systemService, m_outputMessageQueue.get()));
 
   m_internalMessageQueue->addListener(
     std::make_unique<JumpMessageConsumer>(systemService,
@@ -131,15 +143,15 @@ void MessageExchanger::initializeInternalConsumers(const MessageSystemData &mess
                                           messagesData.systemProcessors,
                                           m_outputMessageQueue.get()));
 
-  m_internalMessageQueue->addListener(
-    std::make_unique<EntityRemovedMessageConsumer>(systemService,
-                                                   messagesData.systemProcessors,
-                                                   m_outputMessageQueue.get()));
+  // m_internalMessageQueue->addListener(
+  //   std::make_unique<EntityRemovedMessageConsumer>(systemService,
+  //                                                  messagesData.systemProcessors,
+  //                                                  m_outputMessageQueue.get()));
 
-  m_internalMessageQueue->addListener(
-    std::make_unique<ComponentSyncMessageConsumer>(systemService,
-                                                   messagesData.systemProcessors,
-                                                   m_outputMessageQueue.get()));
+  // m_internalMessageQueue->addListener(
+  //   std::make_unique<ComponentSyncMessageConsumer>(systemService,
+  //                                                  messagesData.systemProcessors,
+  //                                                  m_outputMessageQueue.get()));
 }
 
 } // namespace bsgo

--- a/src/server/lib/game/MessageExchanger.hh
+++ b/src/server/lib/game/MessageExchanger.hh
@@ -32,9 +32,9 @@ class MessageExchanger
   void pushMessage(IMessagePtr message);
 
   private:
-  NetworkMessageQueuePtr m_inputMessageQueue{};
-  IMessageQueuePtr m_internalMessageQueue{};
   IMessageQueuePtr m_outputMessageQueue{};
+  IMessageQueuePtr m_internalMessageQueue{};
+  NetworkMessageQueuePtr m_inputMessageQueue{};
 
   void initialize(const MessageSystemData &messagesData);
   auto initializeSystemMessageQueue(const MessageSystemData &messagesData) -> IMessageQueuePtr;

--- a/src/server/lib/game/MessageExchanger.hh
+++ b/src/server/lib/game/MessageExchanger.hh
@@ -23,6 +23,7 @@ class MessageExchanger
 {
   public:
   MessageExchanger(const MessageSystemData &messagesData);
+  ~MessageExchanger() = default;
 
   auto getInternalMessageQueue() const -> IMessageQueue *;
   auto getOutputMessageQueue() const -> IMessageQueue *;

--- a/src/server/lib/game/SystemProcessor.cc
+++ b/src/server/lib/game/SystemProcessor.cc
@@ -16,16 +16,7 @@ SystemProcessor::SystemProcessor(const Uuid systemDbId)
 
 SystemProcessor::~SystemProcessor()
 {
-  if (!m_running.load())
-  {
-    return;
-  }
-
-  m_running.store(false);
-  if (m_processingThread.joinable())
-  {
-    m_processingThread.join();
-  }
+  stop();
 }
 
 auto SystemProcessor::getSystemDbId() const -> Uuid
@@ -65,6 +56,20 @@ void SystemProcessor::start()
 
   m_running.store(true);
   m_processingThread = std::thread(&SystemProcessor::asyncSystemProcessing, this);
+}
+
+void SystemProcessor::stop()
+{
+  if (!m_running.load())
+  {
+    return;
+  }
+
+  m_running.store(false);
+  if (m_processingThread.joinable())
+  {
+    m_processingThread.join();
+  }
 }
 
 void SystemProcessor::asyncSystemProcessing()

--- a/src/server/lib/game/SystemProcessor.cc
+++ b/src/server/lib/game/SystemProcessor.cc
@@ -9,6 +9,8 @@ namespace bsgo {
 SystemProcessor::SystemProcessor(const Uuid systemDbId)
   : utils::CoreObject("processor")
   , m_systemDbId(systemDbId)
+  , m_inputMessagesQueue(std::make_unique<SynchronizedMessageQueue>(
+      "synchronized-for-system-processor-" + str(systemDbId)))
 {
   setService("system");
   addModule(str(systemDbId));

--- a/src/server/lib/game/SystemProcessor.hh
+++ b/src/server/lib/game/SystemProcessor.hh
@@ -31,8 +31,7 @@ class SystemProcessor : public utils::CoreObject
 
   private:
   Uuid m_systemDbId{};
-  IMessageQueuePtr m_inputMessagesQueue{
-    std::make_unique<SynchronizedMessageQueue>("input-processor")};
+  IMessageQueuePtr m_inputMessagesQueue{};
   DatabaseEntityMapper m_entityMapper{};
   CoordinatorShPtr m_coordinator{};
   Services m_services{};

--- a/src/server/lib/game/SystemProcessor.hh
+++ b/src/server/lib/game/SystemProcessor.hh
@@ -27,10 +27,12 @@ class SystemProcessor : public utils::CoreObject
   void connectToQueues(IMessageQueue *const internalMessageQueue,
                        IMessageQueue *const outputMessageQueue);
   void start();
+  void stop();
 
   private:
   Uuid m_systemDbId{};
-  IMessageQueuePtr m_inputMessagesQueue{std::make_unique<SynchronizedMessageQueue>()};
+  IMessageQueuePtr m_inputMessagesQueue{
+    std::make_unique<SynchronizedMessageQueue>("input-processor")};
   DatabaseEntityMapper m_entityMapper{};
   CoordinatorShPtr m_coordinator{};
   Services m_services{};

--- a/src/server/lib/queues/BroadcastMessageQueue.cc
+++ b/src/server/lib/queues/BroadcastMessageQueue.cc
@@ -43,7 +43,7 @@ void BroadcastMessageQueue::processMessages(const std::optional<int> &amount)
     processMessage(message);
   });
 
-  processor.processMessages(amount);
+  processor.processMessages("broadcaste", amount);
 }
 
 namespace {

--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -8,6 +8,8 @@
 #include <core_utils/log/StdLogger.hh>
 #include <functional>
 
+#include <iostream>
+
 namespace {
 // https://stackoverflow.com/questions/11468414/using-auto-and-lambda-to-handle-signal
 std::function<void(int)> sigIntProcessing;
@@ -28,12 +30,16 @@ int main(int /*argc*/, char ** /*argv*/)
   try
   {
     bsgo::Server server;
-    sigIntProcessing = [&server](const int /*signal*/) { server.requestStop(); };
+    sigIntProcessing = [&server](const int /*signal*/) {
+      server.requestStop();
+      std::cout << "Successfully requested server to stop" << std::endl;
+    };
     // https://en.cppreference.com/w/cpp/utility/program/signal
     std::signal(SIGINT, sigIntInterceptor);
 
     constexpr auto DEFAULT_SERVER_PORT = 60000;
     server.run(DEFAULT_SERVER_PORT);
+    logger.debug("Server::run is over in main");
   }
   catch (const utils::CoreException &e)
   {


### PR DESCRIPTION
# Work

Detected a segfault happening sometimes when closing the server. We identified two issues:
* Since introducing the system messages in the `TriageMessageConsumer` we actually didn't stop the `SystemProcessor`s when the active run loop of the server was stopped.
* Due to the declaration order of the queues in the `MessageExchanger` we were deleting first the output message queue before all the other queues. This means that a message processed in the internal message queue could try to be pushed when the output message queue was already destroyed.

# How to fix
We did the following:
* create a `stop` method on the `SystemProcessor` class to be called at the end of the active run loop of the `Server`.
* change the declaration order of the queues in the `MessageExchanger`.

Both changes were addressed in [c10c1e4](https://github.com/Knoblauchpilze/bsgalone/commit/c10c1e4fd8e3146a9d488893365e6efce71b3e39).

# Additional work
It would be very nice to improve the logging in the message queues to have more information about who is processing what.