### PR TITLE
feat: Replace core_utils with core_lib

### DIFF
--- a/src/bsgo/CMakeLists.txt
+++ b/src/bsgo/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries (bsgo_lib PUBLIC
 	bsgalone-interface-library
 	pq
 	pqxx
+	core_lib
 	net_lib
 	)
 

--- a/src/bsgo/common/VectorUtils.cc
+++ b/src/bsgo/common/VectorUtils.cc
@@ -1,7 +1,7 @@
 
 #include "VectorUtils.hh"
+#include "SerializationUtils.hh"
 #include "StringUtils.hh"
-#include <core_utils/SerializationUtils.hh>
 
 namespace bsgo {
 
@@ -19,9 +19,9 @@ auto str(const Eigen::Vector3f &v) -> std::string
 
 void serialize(std::ostream &out, const Eigen::Vector3f &value)
 {
-  utils::serialize(out, value(0));
-  utils::serialize(out, value(1));
-  utils::serialize(out, value(2));
+  core::serialize(out, value(0));
+  core::serialize(out, value(1));
+  core::serialize(out, value(2));
 }
 
 void serialize(std::ostream &out, const std::optional<Eigen::Vector3f> &value)
@@ -37,9 +37,9 @@ void serialize(std::ostream &out, const std::optional<Eigen::Vector3f> &value)
 bool deserialize(std::istream &in, Eigen::Vector3f &value)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, value(0));
-  ok &= utils::deserialize(in, value(1));
-  ok &= utils::deserialize(in, value(2));
+  ok &= core::deserialize(in, value(0));
+  ok &= core::deserialize(in, value(1));
+  ok &= core::deserialize(in, value(2));
 
   return ok;
 }

--- a/src/bsgo/components/ComputerSlotComponent.cc
+++ b/src/bsgo/components/ComputerSlotComponent.cc
@@ -15,7 +15,7 @@ ComputerSlotComponent::ComputerSlotComponent(const PlayerComputer &computer)
   , m_damageModifier(computer.damageModifier)
 {}
 
-auto ComputerSlotComponent::duration() const -> std::optional<utils::Duration>
+auto ComputerSlotComponent::duration() const -> std::optional<core::Duration>
 {
   return m_duration;
 }

--- a/src/bsgo/components/ComputerSlotComponent.hh
+++ b/src/bsgo/components/ComputerSlotComponent.hh
@@ -4,7 +4,7 @@
 #include "EntityKind.hh"
 #include "PlayerComputerRepository.hh"
 #include "SlotComponent.hh"
-#include <core_utils/TimeUtils.hh>
+#include "TimeUtils.hh"
 #include <optional>
 #include <unordered_set>
 
@@ -16,12 +16,12 @@ class ComputerSlotComponent : public SlotComponent
   ComputerSlotComponent(const PlayerComputer &computer);
   ~ComputerSlotComponent() override = default;
 
-  auto duration() const -> std::optional<utils::Duration>;
+  auto duration() const -> std::optional<core::Duration>;
   auto allowedTargets() const -> std::optional<std::unordered_set<EntityKind>>;
   auto damageModifier() const -> std::optional<float>;
 
   private:
-  std::optional<utils::Duration> m_duration;
+  std::optional<core::Duration> m_duration;
   std::optional<std::unordered_set<EntityKind>> m_allowedTargets;
   std::optional<float> m_damageModifier;
 };

--- a/src/bsgo/components/EffectComponent.cc
+++ b/src/bsgo/components/EffectComponent.cc
@@ -3,7 +3,7 @@
 
 namespace bsgo {
 
-EffectComponent::EffectComponent(const ComponentType &type, const utils::Duration &duration)
+EffectComponent::EffectComponent(const ComponentType &type, const core::Duration &duration)
   : AbstractComponent(type)
   , m_duration(duration)
 {
@@ -23,7 +23,7 @@ auto EffectComponent::damageModifier() const -> std::optional<float>
 void EffectComponent::update(const float elapsedSeconds)
 {
   constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
-  m_elapsedSinceStart += utils::Milliseconds(
+  m_elapsedSinceStart += core::Milliseconds(
     static_cast<int>(elapsedSeconds * MILLISECONDS_IN_A_SECONDS));
 }
 

--- a/src/bsgo/components/EffectComponent.hh
+++ b/src/bsgo/components/EffectComponent.hh
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "AbstractComponent.hh"
-#include <core_utils/TimeUtils.hh>
+#include "TimeUtils.hh"
 #include <optional>
 
 namespace bsgo {
@@ -10,7 +10,7 @@ namespace bsgo {
 class EffectComponent : public AbstractComponent
 {
   public:
-  EffectComponent(const ComponentType &type, const utils::Duration &duration);
+  EffectComponent(const ComponentType &type, const core::Duration &duration);
   ~EffectComponent() override = default;
 
   bool isFinished() const;
@@ -20,8 +20,8 @@ class EffectComponent : public AbstractComponent
   void update(const float elapsedSeconds) override;
 
   private:
-  utils::Duration m_duration;
-  utils::Duration m_elapsedSinceStart{};
+  core::Duration m_duration;
+  core::Duration m_elapsedSinceStart{};
 };
 
 using EffectComponentShPtr = std::shared_ptr<EffectComponent>;

--- a/src/bsgo/components/IComponent.cc
+++ b/src/bsgo/components/IComponent.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 IComponent::IComponent(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {
   setService("component");
 }

--- a/src/bsgo/components/IComponent.hh
+++ b/src/bsgo/components/IComponent.hh
@@ -2,12 +2,12 @@
 #pragma once
 
 #include "ComponentType.hh"
-#include <core_utils/CoreObject.hh>
+#include "CoreObject.hh"
 #include <memory>
 
 namespace bsgo {
 
-class IComponent : public utils::CoreObject
+class IComponent : public core::CoreObject
 {
   public:
   IComponent(const std::string &name);

--- a/src/bsgo/components/NetworkComponent.cc
+++ b/src/bsgo/components/NetworkComponent.cc
@@ -7,10 +7,10 @@ namespace {
 constexpr auto BASE_SYNC_INTERVAL_MS = 1000;
 constexpr auto MAX_SYNC_JITTER_MS    = 100;
 
-auto generateJitteredSyncInterval() -> utils::Duration
+auto generateJitteredSyncInterval() -> core::Duration
 {
   const auto jitteredSync = BASE_SYNC_INTERVAL_MS + std::rand() % MAX_SYNC_JITTER_MS;
-  return utils::Milliseconds{jitteredSync};
+  return core::Milliseconds{jitteredSync};
 }
 } // namespace
 
@@ -44,7 +44,7 @@ auto NetworkComponent::componentsToSync() const -> const std::unordered_set<Comp
 void NetworkComponent::update(const float elapsedSeconds)
 {
   constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
-  const auto elapsedMillis                 = utils::Milliseconds(
+  const auto elapsedMillis                 = core::Milliseconds(
     static_cast<int>(elapsedSeconds * MILLISECONDS_IN_A_SECONDS));
 
   m_remainingUntilNextSync -= elapsedMillis;

--- a/src/bsgo/components/NetworkComponent.hh
+++ b/src/bsgo/components/NetworkComponent.hh
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "AbstractComponent.hh"
-#include <core_utils/TimeUtils.hh>
+#include "TimeUtils.hh"
 #include <unordered_set>
 
 namespace bsgo {
@@ -25,7 +25,7 @@ class NetworkComponent : public AbstractComponent
   private:
   bool m_needsSync{false};
   std::unordered_set<ComponentType> m_componentsToSync{};
-  utils::Duration m_remainingUntilNextSync{};
+  core::Duration m_remainingUntilNextSync{};
 };
 
 using NetworkComponentShPtr = std::shared_ptr<NetworkComponent>;

--- a/src/bsgo/components/SlotComponent.cc
+++ b/src/bsgo/components/SlotComponent.cc
@@ -75,12 +75,12 @@ auto SlotComponent::reloadPercentage() const -> float
   return *m_elapsedSinceLastFired / reloadAsFloat;
 }
 
-auto SlotComponent::elapsedSinceLastFired() const -> std::optional<utils::Duration>
+auto SlotComponent::elapsedSinceLastFired() const -> std::optional<core::Duration>
 {
   return m_elapsedSinceLastFired;
 }
 
-void SlotComponent::overrideElapsedSinceLastFired(const std::optional<utils::Duration> &elapsed)
+void SlotComponent::overrideElapsedSinceLastFired(const std::optional<core::Duration> &elapsed)
 {
   m_elapsedSinceLastFired = elapsed;
 }
@@ -108,7 +108,7 @@ void SlotComponent::fire()
     error("Failed to use slot", "Still reloading");
   }
 
-  m_elapsedSinceLastFired = utils::Duration(0);
+  m_elapsedSinceLastFired = core::Duration(0);
 }
 
 void SlotComponent::clearFireRequest()
@@ -124,7 +124,7 @@ void SlotComponent::handleReload(const float elapsedSeconds)
   }
 
   constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
-  (*m_elapsedSinceLastFired) += utils::Milliseconds(
+  (*m_elapsedSinceLastFired) += core::Milliseconds(
     static_cast<int>(elapsedSeconds * MILLISECONDS_IN_A_SECONDS));
 
   if (*m_elapsedSinceLastFired >= m_reloadTime)

--- a/src/bsgo/components/SlotComponent.hh
+++ b/src/bsgo/components/SlotComponent.hh
@@ -2,8 +2,8 @@
 #pragma once
 
 #include "AbstractComponent.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/TimeUtils.hh>
 #include <optional>
 
 namespace bsgo {
@@ -14,7 +14,7 @@ struct SlotComponentData
   bool offensive{};
   float powerCost{};
   std::optional<float> range{};
-  utils::Duration reloadTime{};
+  core::Duration reloadTime{};
 };
 
 enum class FiringState
@@ -44,9 +44,9 @@ class SlotComponent : public AbstractComponent
   bool canFire() const noexcept;
   bool isReloading() const noexcept;
   auto reloadPercentage() const -> float;
-  auto elapsedSinceLastFired() const -> std::optional<utils::Duration>;
+  auto elapsedSinceLastFired() const -> std::optional<core::Duration>;
 
-  void overrideElapsedSinceLastFired(const std::optional<utils::Duration> &elapsed);
+  void overrideElapsedSinceLastFired(const std::optional<core::Duration> &elapsed);
   void setFiringState(const FiringState &firingState);
   void registerFireRequest();
   bool hasFireRequest() const;
@@ -58,11 +58,11 @@ class SlotComponent : public AbstractComponent
   bool m_offensive;
   float m_powerCost;
   std::optional<float> m_range;
-  utils::Duration m_reloadTime;
+  core::Duration m_reloadTime;
 
   bool m_fireRequest{false};
   FiringState m_firingState{FiringState::READY};
-  std::optional<utils::Duration> m_elapsedSinceLastFired{};
+  std::optional<core::Duration> m_elapsedSinceLastFired{};
 
   void handleReload(const float elapsedSeconds);
 };

--- a/src/bsgo/components/StatusComponent.cc
+++ b/src/bsgo/components/StatusComponent.cc
@@ -4,8 +4,8 @@
 namespace bsgo {
 
 StatusComponent::StatusComponent(const Status &status,
-                                 const std::optional<utils::Duration> &jumpTime,
-                                 const std::optional<utils::Duration> &threatJumpTime)
+                                 const std::optional<core::Duration> &jumpTime,
+                                 const std::optional<core::Duration> &threatJumpTime)
   : AbstractComponent(ComponentType::STATUS)
   , m_status(status)
   , m_jumpTime(jumpTime)
@@ -25,7 +25,7 @@ bool StatusComponent::isDead() const
   return Status::DEAD == m_status;
 }
 
-auto StatusComponent::jumpTime() const -> utils::Duration
+auto StatusComponent::jumpTime() const -> core::Duration
 {
   if (!m_jumpTime)
   {
@@ -34,7 +34,7 @@ auto StatusComponent::jumpTime() const -> utils::Duration
   return *m_jumpTime;
 }
 
-auto StatusComponent::threatJumpTime() const -> utils::Duration
+auto StatusComponent::threatJumpTime() const -> core::Duration
 {
   if (!m_threatJumpTime)
   {
@@ -55,20 +55,20 @@ void StatusComponent::resetChanged()
 
 void StatusComponent::resetAppearingTime()
 {
-  m_elapsedSinceAppearing = utils::Duration{0};
+  m_elapsedSinceAppearing = core::Duration{0};
 }
 
-auto StatusComponent::getElapsedSinceLastChange() const -> utils::Duration
+auto StatusComponent::getElapsedSinceLastChange() const -> core::Duration
 {
   return m_elapsedSinceLastChange;
 }
 
-auto StatusComponent::tryGetElapsedSinceLastAppearing() const -> std::optional<utils::Duration>
+auto StatusComponent::tryGetElapsedSinceLastAppearing() const -> std::optional<core::Duration>
 {
   return m_elapsedSinceAppearing;
 }
 
-auto StatusComponent::tryGetCurrentJumpTime() const -> utils::Duration
+auto StatusComponent::tryGetCurrentJumpTime() const -> core::Duration
 {
   if (!m_currentJumpTime)
   {
@@ -77,7 +77,7 @@ auto StatusComponent::tryGetCurrentJumpTime() const -> utils::Duration
   return *m_currentJumpTime;
 }
 
-auto StatusComponent::tryGetElapsedSinceJumpStarted() const -> utils::Duration
+auto StatusComponent::tryGetElapsedSinceJumpStarted() const -> core::Duration
 {
   if (!m_elapsedSinceJumpStarted)
   {
@@ -86,7 +86,7 @@ auto StatusComponent::tryGetElapsedSinceJumpStarted() const -> utils::Duration
   return *m_elapsedSinceJumpStarted;
 }
 
-auto StatusComponent::tryGetRemainingJumpTime() const -> utils::Duration
+auto StatusComponent::tryGetRemainingJumpTime() const -> core::Duration
 {
   const auto jumpTime = tryGetCurrentJumpTime();
   const auto elapsed  = tryGetElapsedSinceJumpStarted();
@@ -101,13 +101,13 @@ void StatusComponent::setStatus(const Status &status)
 
   m_status                 = status;
   m_justChanged            = true;
-  m_elapsedSinceLastChange = utils::Duration{0};
+  m_elapsedSinceLastChange = core::Duration{0};
 }
 
 void StatusComponent::update(const float elapsedSeconds)
 {
   constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
-  const auto elapsedMillis                 = utils::Milliseconds(
+  const auto elapsedMillis                 = core::Milliseconds(
     static_cast<int>(elapsedSeconds * MILLISECONDS_IN_A_SECONDS));
 
   m_elapsedSinceLastChange += elapsedMillis;
@@ -132,7 +132,7 @@ void StatusComponent::updateJumpState(const Status &newStatus, const bool forceU
   const auto isJumping  = statusIndicatesJump(newStatus);
   if (!wasJumping && isJumping)
   {
-    m_elapsedSinceJumpStarted = utils::Duration{0};
+    m_elapsedSinceJumpStarted = core::Duration{0};
     m_currentJumpTime         = statusIndicatesThreat(m_status) ? *m_threatJumpTime : *m_jumpTime;
   }
   if (wasJumping && !isJumping)
@@ -151,7 +151,7 @@ void StatusComponent::updateAppearingState(const Status &newStatus)
 
   if (statusIndicatesAppearing(newStatus))
   {
-    m_elapsedSinceAppearing = utils::Duration{0};
+    m_elapsedSinceAppearing = core::Duration{0};
   }
 }
 

--- a/src/bsgo/components/StatusComponent.hh
+++ b/src/bsgo/components/StatusComponent.hh
@@ -3,7 +3,7 @@
 
 #include "AbstractComponent.hh"
 #include "Status.hh"
-#include <core_utils/TimeUtils.hh>
+#include "TimeUtils.hh"
 #include <optional>
 
 namespace bsgo {
@@ -12,22 +12,22 @@ class StatusComponent : public AbstractComponent
 {
   public:
   StatusComponent(const Status &status,
-                  const std::optional<utils::Duration> &jumpTime,
-                  const std::optional<utils::Duration> &threatJumpTime);
+                  const std::optional<core::Duration> &jumpTime,
+                  const std::optional<core::Duration> &threatJumpTime);
   ~StatusComponent() = default;
 
   auto status() const -> Status;
   bool isDead() const;
-  auto jumpTime() const -> utils::Duration;
-  auto threatJumpTime() const -> utils::Duration;
+  auto jumpTime() const -> core::Duration;
+  auto threatJumpTime() const -> core::Duration;
   bool justChanged() const;
   void resetChanged();
   void resetAppearingTime();
-  auto getElapsedSinceLastChange() const -> utils::Duration;
-  auto tryGetElapsedSinceLastAppearing() const -> std::optional<utils::Duration>;
-  auto tryGetCurrentJumpTime() const -> utils::Duration;
-  auto tryGetElapsedSinceJumpStarted() const -> utils::Duration;
-  auto tryGetRemainingJumpTime() const -> utils::Duration;
+  auto getElapsedSinceLastChange() const -> core::Duration;
+  auto tryGetElapsedSinceLastAppearing() const -> std::optional<core::Duration>;
+  auto tryGetCurrentJumpTime() const -> core::Duration;
+  auto tryGetElapsedSinceJumpStarted() const -> core::Duration;
+  auto tryGetRemainingJumpTime() const -> core::Duration;
 
   void setStatus(const Status &status);
 
@@ -35,13 +35,13 @@ class StatusComponent : public AbstractComponent
 
   private:
   Status m_status;
-  std::optional<utils::Duration> m_jumpTime{};
-  std::optional<utils::Duration> m_threatJumpTime{};
+  std::optional<core::Duration> m_jumpTime{};
+  std::optional<core::Duration> m_threatJumpTime{};
   bool m_justChanged{false};
-  utils::Duration m_elapsedSinceLastChange{};
-  std::optional<utils::Duration> m_elapsedSinceAppearing{};
-  std::optional<utils::Duration> m_elapsedSinceJumpStarted{};
-  std::optional<utils::Duration> m_currentJumpTime{};
+  core::Duration m_elapsedSinceLastChange{};
+  std::optional<core::Duration> m_elapsedSinceAppearing{};
+  std::optional<core::Duration> m_elapsedSinceJumpStarted{};
+  std::optional<core::Duration> m_currentJumpTime{};
 
   void updateJumpState(const Status &newStatus, const bool forceUpdate);
   void updateAppearingState(const Status &newStatus);

--- a/src/bsgo/components/WeaponEffectComponent.cc
+++ b/src/bsgo/components/WeaponEffectComponent.cc
@@ -3,7 +3,7 @@
 
 namespace bsgo {
 
-WeaponEffectComponent::WeaponEffectComponent(const utils::Duration &duration,
+WeaponEffectComponent::WeaponEffectComponent(const core::Duration &duration,
                                              const float damageModifier)
   : EffectComponent(ComponentType::WEAPON_EFFECT, duration)
   , m_damageModifier(damageModifier)

--- a/src/bsgo/components/WeaponEffectComponent.hh
+++ b/src/bsgo/components/WeaponEffectComponent.hh
@@ -2,14 +2,14 @@
 #pragma once
 
 #include "EffectComponent.hh"
-#include <core_utils/TimeUtils.hh>
+#include "TimeUtils.hh"
 
 namespace bsgo {
 
 class WeaponEffectComponent : public EffectComponent
 {
   public:
-  WeaponEffectComponent(const utils::Duration &duration, const float damageModifier);
+  WeaponEffectComponent(const core::Duration &duration, const float damageModifier);
   ~WeaponEffectComponent() override = default;
 
   auto damageModifier() const -> std::optional<float> override;

--- a/src/bsgo/consumers/AbstractMessageConsumer.cc
+++ b/src/bsgo/consumers/AbstractMessageConsumer.cc
@@ -7,7 +7,7 @@ AbstractMessageConsumer::AbstractMessageConsumer(
   const std::string &name,
   const std::unordered_set<MessageType> &relevantMessageTypes)
   : AbstractMessageListener(relevantMessageTypes)
-  , utils::CoreObject(name)
+  , core::CoreObject(name)
 {
   setService("consumer");
 }

--- a/src/bsgo/consumers/AbstractMessageConsumer.hh
+++ b/src/bsgo/consumers/AbstractMessageConsumer.hh
@@ -2,11 +2,11 @@
 #pragma once
 
 #include "AbstractMessageListener.hh"
-#include <core_utils/CoreObject.hh>
+#include "CoreObject.hh"
 
 namespace bsgo {
 
-class AbstractMessageConsumer : public AbstractMessageListener, public utils::CoreObject
+class AbstractMessageConsumer : public AbstractMessageListener, public core::CoreObject
 {
   public:
   AbstractMessageConsumer(const std::string &name,

--- a/src/bsgo/controller/Coordinator.cc
+++ b/src/bsgo/controller/Coordinator.cc
@@ -47,7 +47,7 @@ auto getAllComponent(const Uuid ent,
 } // namespace
 
 Coordinator::Coordinator(SystemsConfig &&config)
-  : utils::CoreObject("coordinator")
+  : core::CoreObject("coordinator")
   , m_systems(std::make_unique<Systems>(std::move(config)))
 {
   setService("bsgo");
@@ -145,8 +145,8 @@ void Coordinator::addRemoval(const Uuid ent)
 
 void Coordinator::addStatus(const Uuid ent,
                             const Status &status,
-                            const std::optional<utils::Duration> &jumpTime,
-                            const std::optional<utils::Duration> &threatJumpTime)
+                            const std::optional<core::Duration> &jumpTime,
+                            const std::optional<core::Duration> &threatJumpTime)
 {
   checkForOverrides(ent, "Status", m_components.statuses);
   m_components.statuses[ent] = std::make_shared<StatusComponent>(status, jumpTime, threatJumpTime);
@@ -203,7 +203,7 @@ void Coordinator::addResourceComponent(const Uuid ent, const Uuid resource, cons
 }
 
 void Coordinator::addWeaponEffect(const Uuid ent,
-                                  const utils::Duration &duration,
+                                  const core::Duration &duration,
                                   const float damageModifier)
 {
   checkEntityExist(ent, "WeaponEffect");

--- a/src/bsgo/controller/Coordinator.hh
+++ b/src/bsgo/controller/Coordinator.hh
@@ -2,13 +2,13 @@
 #pragma once
 
 #include "Components.hh"
+#include "CoreObject.hh"
 #include "Entity.hh"
 #include "IBoundingBox.hh"
 #include "IMessageQueue.hh"
 #include "Systems.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/CoreObject.hh>
-#include <core_utils/TimeUtils.hh>
 #include <eigen3/Eigen/Eigen>
 #include <memory>
 #include <optional>
@@ -18,7 +18,7 @@ namespace bsgo {
 
 class DataSource;
 
-class Coordinator : public utils::CoreObject
+class Coordinator : public core::CoreObject
 {
   public:
   Coordinator(SystemsConfig &&config);
@@ -42,8 +42,8 @@ class Coordinator : public utils::CoreObject
   void addRemoval(const Uuid ent);
   void addStatus(const Uuid ent,
                  const Status &status,
-                 const std::optional<utils::Duration> &jumpTime,
-                 const std::optional<utils::Duration> &threatJumpTime);
+                 const std::optional<core::Duration> &jumpTime,
+                 const std::optional<core::Duration> &threatJumpTime);
   void addAI(const Uuid ent, INodePtr behavior);
   void addShipClass(const Uuid ent, const ShipClass &shipClass);
   void addName(const Uuid ent, const std::string &name);
@@ -53,7 +53,7 @@ class Coordinator : public utils::CoreObject
   void addComputer(const Uuid ent, const PlayerComputer &computer);
   void addResourceComponent(const Uuid ent, const Uuid resource, const float amount);
 
-  void addWeaponEffect(const Uuid ent, const utils::Duration &duration, const float damageModifier);
+  void addWeaponEffect(const Uuid ent, const core::Duration &duration, const float damageModifier);
   void removeEffect(const Uuid ent, const EffectComponentShPtr &effect);
 
   auto getEntity(const Uuid ent) const -> Entity;

--- a/src/bsgo/controller/Systems.cc
+++ b/src/bsgo/controller/Systems.cc
@@ -19,7 +19,7 @@
 namespace bsgo {
 
 Systems::Systems(SystemsConfig &&config)
-  : utils::CoreObject("systems")
+  : core::CoreObject("systems")
 {
   setService("bsgo");
 

--- a/src/bsgo/controller/Systems.hh
+++ b/src/bsgo/controller/Systems.hh
@@ -1,10 +1,10 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "IMessageQueue.hh"
 #include "ISystem.hh"
 #include "NetworkSystem.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <unordered_set>
 #include <vector>
@@ -21,7 +21,7 @@ struct SystemsConfig
   std::unordered_set<SystemType> ignoredSystems{};
 };
 
-class Systems : public utils::CoreObject
+class Systems : public core::CoreObject
 {
   public:
   Systems(SystemsConfig &&config);

--- a/src/bsgo/data/AsteroidDataSource.cc
+++ b/src/bsgo/data/AsteroidDataSource.cc
@@ -6,7 +6,7 @@
 namespace bsgo {
 
 AsteroidDataSource::AsteroidDataSource(const Repositories &repositories)
-  : utils::CoreObject("bsgo")
+  : core::CoreObject("bsgo")
   , m_repositories(repositories)
 {
   setService("data");

--- a/src/bsgo/data/AsteroidDataSource.hh
+++ b/src/bsgo/data/AsteroidDataSource.hh
@@ -1,15 +1,15 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "DatabaseEntityMapper.hh"
 #include "Repositories.hh"
-#include <core_utils/CoreObject.hh>
 
 namespace bsgo {
 
 class Coordinator;
 
-class AsteroidDataSource : public utils::CoreObject
+class AsteroidDataSource : public core::CoreObject
 {
   public:
   AsteroidDataSource(const Repositories &repositories);

--- a/src/bsgo/data/DataSource.cc
+++ b/src/bsgo/data/DataSource.cc
@@ -9,7 +9,7 @@
 namespace bsgo {
 
 DataSource::DataSource(const DataLoadingMode dataLoadingMode)
-  : utils::CoreObject("bsgo")
+  : core::CoreObject("bsgo")
   , m_dataLoadingMode(dataLoadingMode)
 {
   setService("data");

--- a/src/bsgo/data/DataSource.hh
+++ b/src/bsgo/data/DataSource.hh
@@ -1,16 +1,16 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "DataLoadingMode.hh"
 #include "DatabaseEntityMapper.hh"
 #include "Repositories.hh"
-#include <core_utils/CoreObject.hh>
 
 namespace bsgo {
 
 class Coordinator;
 
-class DataSource : public utils::CoreObject
+class DataSource : public core::CoreObject
 {
   public:
   DataSource(const DataLoadingMode dataLoadingMode);

--- a/src/bsgo/data/DatabaseEntityMapper.cc
+++ b/src/bsgo/data/DatabaseEntityMapper.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 DatabaseEntityMapper::DatabaseEntityMapper()
-  : utils::CoreObject("database")
+  : core::CoreObject("database")
 {
   setService("mapper");
 }

--- a/src/bsgo/data/DatabaseEntityMapper.hh
+++ b/src/bsgo/data/DatabaseEntityMapper.hh
@@ -1,8 +1,8 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "Uuid.hh"
-#include <core_utils/CoreObject.hh>
 #include <mutex>
 #include <optional>
 #include <unordered_map>
@@ -11,7 +11,7 @@ namespace bsgo {
 
 using DbIdsToEntityIds = std::unordered_map<Uuid, Uuid>;
 
-class DatabaseEntityMapper : public utils::CoreObject
+class DatabaseEntityMapper : public core::CoreObject
 {
   public:
   DatabaseEntityMapper();

--- a/src/bsgo/data/OutpostDataSource.cc
+++ b/src/bsgo/data/OutpostDataSource.cc
@@ -6,7 +6,7 @@
 namespace bsgo {
 
 OutpostDataSource::OutpostDataSource(const Repositories &repositories)
-  : utils::CoreObject("bsgo")
+  : core::CoreObject("bsgo")
   , m_repositories(repositories)
 {
   setService("data");

--- a/src/bsgo/data/OutpostDataSource.hh
+++ b/src/bsgo/data/OutpostDataSource.hh
@@ -1,15 +1,15 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "DatabaseEntityMapper.hh"
 #include "Repositories.hh"
-#include <core_utils/CoreObject.hh>
 
 namespace bsgo {
 
 class Coordinator;
 
-class OutpostDataSource : public utils::CoreObject
+class OutpostDataSource : public core::CoreObject
 {
   public:
   OutpostDataSource(const Repositories &repositories);

--- a/src/bsgo/data/PlayerDataSource.cc
+++ b/src/bsgo/data/PlayerDataSource.cc
@@ -5,7 +5,7 @@
 namespace bsgo {
 
 PlayerDataSource::PlayerDataSource(const Repositories &repositories)
-  : utils::CoreObject("bsgo")
+  : core::CoreObject("bsgo")
   , m_repositories(repositories)
 {
   setService("data");

--- a/src/bsgo/data/PlayerDataSource.hh
+++ b/src/bsgo/data/PlayerDataSource.hh
@@ -1,15 +1,15 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "DatabaseEntityMapper.hh"
 #include "Repositories.hh"
-#include <core_utils/CoreObject.hh>
 
 namespace bsgo {
 
 class Coordinator;
 
-class PlayerDataSource : public utils::CoreObject
+class PlayerDataSource : public core::CoreObject
 {
   public:
   PlayerDataSource(const Repositories &repositories);

--- a/src/bsgo/data/ShipDataSource.cc
+++ b/src/bsgo/data/ShipDataSource.cc
@@ -2,8 +2,8 @@
 #include "ShipDataSource.hh"
 #include "CircleBox.hh"
 #include "Coordinator.hh"
+#include "RNG.hh"
 #include "VectorUtils.hh"
-#include <core_utils/RNG.hh>
 
 #include "FallbackNode.hh"
 #include "FireNode.hh"
@@ -16,7 +16,7 @@
 namespace bsgo {
 
 ShipDataSource::ShipDataSource(const Repositories &repositories)
-  : utils::CoreObject("bsgo")
+  : core::CoreObject("bsgo")
   , m_repositories(repositories)
 {
   setService("data");
@@ -148,7 +148,7 @@ auto ShipDataSource::generateBehaviorTree(const Uuid entity, const Eigen::Vector
   -> INodePtr
 {
   constexpr auto RADIUS_TO_PICK_A_TARGET = 5.0f;
-  utils::RNG rng(entity);
+  core::RNG rng(entity);
 
   auto dx                       = rng.rndFloat(-RADIUS_TO_PICK_A_TARGET, RADIUS_TO_PICK_A_TARGET);
   auto dy                       = rng.rndFloat(-RADIUS_TO_PICK_A_TARGET, RADIUS_TO_PICK_A_TARGET);

--- a/src/bsgo/data/ShipDataSource.hh
+++ b/src/bsgo/data/ShipDataSource.hh
@@ -1,18 +1,18 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "DatabaseEntityMapper.hh"
 #include "INode.hh"
 #include "PlayerShipRepository.hh"
 #include "Repositories.hh"
-#include <core_utils/CoreObject.hh>
 #include <unordered_map>
 
 namespace bsgo {
 
 class Coordinator;
 
-class ShipDataSource : public utils::CoreObject
+class ShipDataSource : public core::CoreObject
 {
   public:
   ShipDataSource(const Repositories &repositories);

--- a/src/bsgo/messages/ComponentSyncMessage.cc
+++ b/src/bsgo/messages/ComponentSyncMessage.cc
@@ -1,6 +1,6 @@
 
 #include "ComponentSyncMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -105,19 +105,19 @@ auto ComponentSyncMessage::tryGetPower() const -> std::optional<float>
 
 auto ComponentSyncMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
 
-  utils::serialize(out, m_entityDbId);
-  utils::serialize(out, m_entityKind);
+  core::serialize(out, m_entityDbId);
+  core::serialize(out, m_entityKind);
 
-  utils::serialize(out, m_systemDbId);
-  utils::serialize(out, m_status);
-  utils::serialize(out, m_position);
-  utils::serialize(out, m_speed);
-  utils::serialize(out, m_acceleration);
-  utils::serialize(out, m_health);
-  utils::serialize(out, m_power);
+  core::serialize(out, m_systemDbId);
+  core::serialize(out, m_status);
+  core::serialize(out, m_position);
+  core::serialize(out, m_speed);
+  core::serialize(out, m_acceleration);
+  core::serialize(out, m_health);
+  core::serialize(out, m_power);
 
   return out;
 }
@@ -125,19 +125,19 @@ auto ComponentSyncMessage::serialize(std::ostream &out) const -> std::ostream &
 bool ComponentSyncMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_entityDbId);
-  ok &= utils::deserialize(in, m_entityKind);
+  ok &= core::deserialize(in, m_entityDbId);
+  ok &= core::deserialize(in, m_entityKind);
 
-  ok &= utils::deserialize(in, m_systemDbId);
-  ok &= utils::deserialize(in, m_status);
-  ok &= utils::deserialize(in, m_position);
-  ok &= utils::deserialize(in, m_speed);
-  ok &= utils::deserialize(in, m_acceleration);
-  ok &= utils::deserialize(in, m_health);
-  ok &= utils::deserialize(in, m_power);
+  ok &= core::deserialize(in, m_systemDbId);
+  ok &= core::deserialize(in, m_status);
+  ok &= core::deserialize(in, m_position);
+  ok &= core::deserialize(in, m_speed);
+  ok &= core::deserialize(in, m_acceleration);
+  ok &= core::deserialize(in, m_health);
+  ok &= core::deserialize(in, m_power);
 
   return ok;
 }

--- a/src/bsgo/messages/ConnectionMessage.cc
+++ b/src/bsgo/messages/ConnectionMessage.cc
@@ -1,6 +1,6 @@
 
 #include "ConnectionMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -16,9 +16,9 @@ ConnectionMessage::ConnectionMessage(const Uuid clientId)
 
 auto ConnectionMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
   return out;
 }
@@ -26,9 +26,9 @@ auto ConnectionMessage::serialize(std::ostream &out) const -> std::ostream &
 bool ConnectionMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
   return ok;
 }

--- a/src/bsgo/messages/DockMessage.cc
+++ b/src/bsgo/messages/DockMessage.cc
@@ -1,6 +1,6 @@
 
 #include "DockMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -32,13 +32,13 @@ auto DockMessage::getSystemDbId() const -> Uuid
 
 auto DockMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_shipDbId);
-  utils::serialize(out, m_docking);
-  utils::serialize(out, m_systemDbId);
+  core::serialize(out, m_shipDbId);
+  core::serialize(out, m_docking);
+  core::serialize(out, m_systemDbId);
 
   return out;
 }
@@ -46,13 +46,13 @@ auto DockMessage::serialize(std::ostream &out) const -> std::ostream &
 bool DockMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_shipDbId);
-  ok &= utils::deserialize(in, m_docking);
-  ok &= utils::deserialize(in, m_systemDbId);
+  ok &= core::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_docking);
+  ok &= core::deserialize(in, m_systemDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/EntityAddedMessage.cc
+++ b/src/bsgo/messages/EntityAddedMessage.cc
@@ -1,6 +1,6 @@
 
 #include "EntityAddedMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -34,12 +34,12 @@ auto EntityAddedMessage::getSystemDbId() const -> Uuid
 
 auto EntityAddedMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
 
-  utils::serialize(out, m_entityDbId);
-  utils::serialize(out, m_entityKind);
-  utils::serialize(out, m_systemDbId);
+  core::serialize(out, m_entityDbId);
+  core::serialize(out, m_entityKind);
+  core::serialize(out, m_systemDbId);
 
   return out;
 }
@@ -47,12 +47,12 @@ auto EntityAddedMessage::serialize(std::ostream &out) const -> std::ostream &
 bool EntityAddedMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_entityDbId);
-  ok &= utils::deserialize(in, m_entityKind);
-  ok &= utils::deserialize(in, m_systemDbId);
+  ok &= core::deserialize(in, m_entityDbId);
+  ok &= core::deserialize(in, m_entityKind);
+  ok &= core::deserialize(in, m_systemDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/EntityRemovedMessage.cc
+++ b/src/bsgo/messages/EntityRemovedMessage.cc
@@ -1,6 +1,6 @@
 
 #include "EntityRemovedMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -59,13 +59,13 @@ auto EntityRemovedMessage::tryGetSystemDbId() const -> std::optional<Uuid>
 
 auto EntityRemovedMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
 
-  utils::serialize(out, m_entityDbId);
-  utils::serialize(out, m_entityKind);
-  utils::serialize(out, m_dead);
-  utils::serialize(out, m_systemDbId);
+  core::serialize(out, m_entityDbId);
+  core::serialize(out, m_entityKind);
+  core::serialize(out, m_dead);
+  core::serialize(out, m_systemDbId);
 
   return out;
 }
@@ -73,13 +73,13 @@ auto EntityRemovedMessage::serialize(std::ostream &out) const -> std::ostream &
 bool EntityRemovedMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_entityDbId);
-  ok &= utils::deserialize(in, m_entityKind);
-  ok &= utils::deserialize(in, m_dead);
-  ok &= utils::deserialize(in, m_systemDbId);
+  ok &= core::deserialize(in, m_entityDbId);
+  ok &= core::deserialize(in, m_entityKind);
+  ok &= core::deserialize(in, m_dead);
+  ok &= core::deserialize(in, m_systemDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/EquipMessage.cc
+++ b/src/bsgo/messages/EquipMessage.cc
@@ -1,6 +1,6 @@
 
 #include "EquipMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -41,14 +41,14 @@ auto EquipMessage::getItemDbId() const -> Uuid
 
 auto EquipMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_action);
-  utils::serialize(out, m_shipDbId);
-  utils::serialize(out, m_itemType);
-  utils::serialize(out, m_itemDbId);
+  core::serialize(out, m_action);
+  core::serialize(out, m_shipDbId);
+  core::serialize(out, m_itemType);
+  core::serialize(out, m_itemDbId);
 
   return out;
 }
@@ -56,14 +56,14 @@ auto EquipMessage::serialize(std::ostream &out) const -> std::ostream &
 bool EquipMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_action);
-  ok &= utils::deserialize(in, m_shipDbId);
-  ok &= utils::deserialize(in, m_itemType);
-  ok &= utils::deserialize(in, m_itemDbId);
+  ok &= core::deserialize(in, m_action);
+  ok &= core::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_itemType);
+  ok &= core::deserialize(in, m_itemDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/HangarMessage.cc
+++ b/src/bsgo/messages/HangarMessage.cc
@@ -1,7 +1,7 @@
 
 
 #include "HangarMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -21,11 +21,11 @@ auto HangarMessage::getShipDbId() const -> Uuid
 
 auto HangarMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_shipDbId);
+  core::serialize(out, m_shipDbId);
 
   return out;
 }
@@ -33,11 +33,11 @@ auto HangarMessage::serialize(std::ostream &out) const -> std::ostream &
 bool HangarMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_shipDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/IMessage.cc
+++ b/src/bsgo/messages/IMessage.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 IMessage::IMessage(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {
   setService("message");
 }

--- a/src/bsgo/messages/IMessage.hh
+++ b/src/bsgo/messages/IMessage.hh
@@ -1,13 +1,13 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "MessageType.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 
 namespace bsgo {
 
-class IMessage : public utils::CoreObject
+class IMessage : public core::CoreObject
 {
   public:
   IMessage(const std::string &name);

--- a/src/bsgo/messages/JumpCancelledMessage.cc
+++ b/src/bsgo/messages/JumpCancelledMessage.cc
@@ -1,6 +1,6 @@
 
 #include "JumpCancelledMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -20,11 +20,11 @@ auto JumpCancelledMessage::getShipDbId() const -> Uuid
 
 auto JumpCancelledMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_shipDbId);
+  core::serialize(out, m_shipDbId);
 
   return out;
 }
@@ -32,11 +32,11 @@ auto JumpCancelledMessage::serialize(std::ostream &out) const -> std::ostream &
 bool JumpCancelledMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_shipDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/JumpMessage.cc
+++ b/src/bsgo/messages/JumpMessage.cc
@@ -1,6 +1,6 @@
 
 #include "JumpMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -65,13 +65,13 @@ auto JumpMessage::getDestinationSystemDbId() const -> Uuid
 
 auto JumpMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
 
-  utils::serialize(out, m_shipDbId);
-  utils::serialize(out, m_playerDbId);
-  utils::serialize(out, m_sourceSystemDbId);
-  utils::serialize(out, m_destinationSystemDbId);
+  core::serialize(out, m_shipDbId);
+  core::serialize(out, m_playerDbId);
+  core::serialize(out, m_sourceSystemDbId);
+  core::serialize(out, m_destinationSystemDbId);
 
   return out;
 }
@@ -79,13 +79,13 @@ auto JumpMessage::serialize(std::ostream &out) const -> std::ostream &
 bool JumpMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_shipDbId);
-  ok &= utils::deserialize(in, m_playerDbId);
-  ok &= utils::deserialize(in, m_sourceSystemDbId);
-  ok &= utils::deserialize(in, m_destinationSystemDbId);
+  ok &= core::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_playerDbId);
+  ok &= core::deserialize(in, m_sourceSystemDbId);
+  ok &= core::deserialize(in, m_destinationSystemDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/JumpRequestedMessage.cc
+++ b/src/bsgo/messages/JumpRequestedMessage.cc
@@ -1,6 +1,6 @@
 
 #include "JumpRequestedMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -26,12 +26,12 @@ auto JumpRequestedMessage::getJumpSystem() const -> Uuid
 
 auto JumpRequestedMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_shipDbId);
-  utils::serialize(out, m_systemDbId);
+  core::serialize(out, m_shipDbId);
+  core::serialize(out, m_systemDbId);
 
   return out;
 }
@@ -39,12 +39,12 @@ auto JumpRequestedMessage::serialize(std::ostream &out) const -> std::ostream &
 bool JumpRequestedMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_shipDbId);
-  ok &= utils::deserialize(in, m_systemDbId);
+  ok &= core::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_systemDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/LoginMessage.cc
+++ b/src/bsgo/messages/LoginMessage.cc
@@ -1,6 +1,6 @@
 
 #include "LoginMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -43,14 +43,14 @@ auto LoginMessage::getPlayerDbId() const -> std::optional<Uuid>
 
 auto LoginMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_name);
-  utils::serialize(out, m_password);
+  core::serialize(out, m_name);
+  core::serialize(out, m_password);
 
-  utils::serialize(out, m_playerDbId);
+  core::serialize(out, m_playerDbId);
 
   return out;
 }
@@ -58,14 +58,14 @@ auto LoginMessage::serialize(std::ostream &out) const -> std::ostream &
 bool LoginMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_name);
-  ok &= utils::deserialize(in, m_password);
+  ok &= core::deserialize(in, m_name);
+  ok &= core::deserialize(in, m_password);
 
-  ok &= utils::deserialize(in, m_playerDbId);
+  ok &= core::deserialize(in, m_playerDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/LogoutMessage.cc
+++ b/src/bsgo/messages/LogoutMessage.cc
@@ -1,6 +1,6 @@
 
 #include "LogoutMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -30,12 +30,12 @@ bool LogoutMessage::shouldCloseConnection() const
 
 auto LogoutMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_playerDbId);
-  utils::serialize(out, m_closeConnection);
+  core::serialize(out, m_playerDbId);
+  core::serialize(out, m_closeConnection);
 
   return out;
 }
@@ -43,12 +43,12 @@ auto LogoutMessage::serialize(std::ostream &out) const -> std::ostream &
 bool LogoutMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_playerDbId);
-  ok &= utils::deserialize(in, m_closeConnection);
+  ok &= core::deserialize(in, m_playerDbId);
+  ok &= core::deserialize(in, m_closeConnection);
 
   return ok;
 }

--- a/src/bsgo/messages/LootMessage.cc
+++ b/src/bsgo/messages/LootMessage.cc
@@ -1,6 +1,6 @@
 
 #include "LootMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -32,12 +32,12 @@ auto LootMessage::amount() const -> float
 
 auto LootMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
 
-  utils::serialize(out, m_playerDbId);
-  utils::serialize(out, m_resourceDbId);
-  utils::serialize(out, m_amount);
+  core::serialize(out, m_playerDbId);
+  core::serialize(out, m_resourceDbId);
+  core::serialize(out, m_amount);
 
   return out;
 }
@@ -45,12 +45,12 @@ auto LootMessage::serialize(std::ostream &out) const -> std::ostream &
 bool LootMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_playerDbId);
-  ok &= utils::deserialize(in, m_resourceDbId);
-  ok &= utils::deserialize(in, m_amount);
+  ok &= core::deserialize(in, m_playerDbId);
+  ok &= core::deserialize(in, m_resourceDbId);
+  ok &= core::deserialize(in, m_amount);
 
   return ok;
 }

--- a/src/bsgo/messages/MessageParser.cc
+++ b/src/bsgo/messages/MessageParser.cc
@@ -1,6 +1,6 @@
 
 #include "MessageParser.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 #include <sstream>
 
 #include "ComponentSyncMessage.hh"
@@ -28,7 +28,7 @@
 namespace bsgo {
 
 MessageParser::MessageParser()
-  : utils::CoreObject("message")
+  : core::CoreObject("message")
 {
   addModule("parser");
   setService("server");
@@ -40,7 +40,7 @@ constexpr auto MESSAGE_SIZE = sizeof(std::underlying_type_t<MessageType>);
 auto tryReadMessageType(std::istream &in) -> std::optional<MessageType>
 {
   MessageType type{};
-  if (!utils::deserialize(in, type))
+  if (!core::deserialize(in, type))
   {
     return {};
   }

--- a/src/bsgo/messages/MessageParser.hh
+++ b/src/bsgo/messages/MessageParser.hh
@@ -1,15 +1,15 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "IMessage.hh"
-#include <core_utils/CoreObject.hh>
 #include <deque>
 #include <istream>
 #include <optional>
 
 namespace bsgo {
 
-class MessageParser : public utils::CoreObject
+class MessageParser : public core::CoreObject
 {
   public:
   MessageParser();

--- a/src/bsgo/messages/PurchaseMessage.cc
+++ b/src/bsgo/messages/PurchaseMessage.cc
@@ -1,6 +1,6 @@
 
 #include "PurchaseMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -32,13 +32,13 @@ auto PurchaseMessage::getItemDbId() const -> Uuid
 
 auto PurchaseMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_playerDbId);
-  utils::serialize(out, m_itemType);
-  utils::serialize(out, m_itemDbId);
+  core::serialize(out, m_playerDbId);
+  core::serialize(out, m_itemType);
+  core::serialize(out, m_itemDbId);
 
   return out;
 }
@@ -46,13 +46,13 @@ auto PurchaseMessage::serialize(std::ostream &out) const -> std::ostream &
 bool PurchaseMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_playerDbId);
-  ok &= utils::deserialize(in, m_itemType);
-  ok &= utils::deserialize(in, m_itemDbId);
+  ok &= core::deserialize(in, m_playerDbId);
+  ok &= core::deserialize(in, m_itemType);
+  ok &= core::deserialize(in, m_itemDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/ScannedMessage.cc
+++ b/src/bsgo/messages/ScannedMessage.cc
@@ -1,6 +1,6 @@
 
 #include "ScannedMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -26,12 +26,12 @@ auto ScannedMessage::getAsteroidDbId() const -> Uuid
 
 auto ScannedMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_playerDbId);
-  utils::serialize(out, m_asteroidDbId);
+  core::serialize(out, m_playerDbId);
+  core::serialize(out, m_asteroidDbId);
 
   return out;
 }
@@ -39,12 +39,12 @@ auto ScannedMessage::serialize(std::ostream &out) const -> std::ostream &
 bool ScannedMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_playerDbId);
-  ok &= utils::deserialize(in, m_asteroidDbId);
+  ok &= core::deserialize(in, m_playerDbId);
+  ok &= core::deserialize(in, m_asteroidDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/SignupMessage.cc
+++ b/src/bsgo/messages/SignupMessage.cc
@@ -1,6 +1,6 @@
 
 #include "SignupMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -52,15 +52,15 @@ auto SignupMessage::getPlayerDbId() const -> std::optional<Uuid>
 
 auto SignupMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_name);
-  utils::serialize(out, m_password);
-  utils::serialize(out, m_faction);
+  core::serialize(out, m_name);
+  core::serialize(out, m_password);
+  core::serialize(out, m_faction);
 
-  utils::serialize(out, m_playerDbId);
+  core::serialize(out, m_playerDbId);
 
   return out;
 }
@@ -68,15 +68,15 @@ auto SignupMessage::serialize(std::ostream &out) const -> std::ostream &
 bool SignupMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_name);
-  ok &= utils::deserialize(in, m_password);
-  ok &= utils::deserialize(in, m_faction);
+  ok &= core::deserialize(in, m_name);
+  ok &= core::deserialize(in, m_password);
+  ok &= core::deserialize(in, m_faction);
 
-  ok &= utils::deserialize(in, m_playerDbId);
+  ok &= core::deserialize(in, m_playerDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/SlotComponentMessage.cc
+++ b/src/bsgo/messages/SlotComponentMessage.cc
@@ -1,6 +1,6 @@
 
 #include "SlotComponentMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -8,12 +8,11 @@ SlotComponentMessage::SlotComponentMessage()
   : ComponentUpdatedMessage(MessageType::SLOT_COMPONENT_UPDATED)
 {}
 
-SlotComponentMessage::SlotComponentMessage(
-  const Uuid playerDbId,
+SlotComponentMessage::SlotComponentMessage(const Uuid playerDbId,
 
-  const Uuid shipDbId,
-  const Uuid slotDbId,
-  const std::optional<utils::Duration> &elapsedSinceLastFired)
+                                           const Uuid shipDbId,
+                                           const Uuid slotDbId,
+                                           const std::optional<core::Duration> &elapsedSinceLastFired)
   : ComponentUpdatedMessage(MessageType::SLOT_COMPONENT_UPDATED,
                             shipDbId,
                             ComponentType::COMPUTER_SLOT)
@@ -32,21 +31,21 @@ auto SlotComponentMessage::getSlotDbId() const -> int
   return m_slotDbId;
 }
 
-auto SlotComponentMessage::getElapsedSinceLastFired() const -> std::optional<utils::Duration>
+auto SlotComponentMessage::getElapsedSinceLastFired() const -> std::optional<core::Duration>
 {
   return m_elapsedSinceLastFired;
 }
 
 auto SlotComponentMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
 
-  utils::serialize(out, m_playerDbId);
-  utils::serialize(out, m_shipDbId);
-  utils::serialize(out, m_component);
-  utils::serialize(out, m_slotDbId);
-  utils::serialize(out, m_elapsedSinceLastFired);
+  core::serialize(out, m_playerDbId);
+  core::serialize(out, m_shipDbId);
+  core::serialize(out, m_component);
+  core::serialize(out, m_slotDbId);
+  core::serialize(out, m_elapsedSinceLastFired);
 
   return out;
 }
@@ -54,14 +53,14 @@ auto SlotComponentMessage::serialize(std::ostream &out) const -> std::ostream &
 bool SlotComponentMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_playerDbId);
-  ok &= utils::deserialize(in, m_shipDbId);
-  ok &= utils::deserialize(in, m_component);
-  ok &= utils::deserialize(in, m_slotDbId);
-  ok &= utils::deserialize(in, m_elapsedSinceLastFired);
+  ok &= core::deserialize(in, m_playerDbId);
+  ok &= core::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_component);
+  ok &= core::deserialize(in, m_slotDbId);
+  ok &= core::deserialize(in, m_elapsedSinceLastFired);
 
   return ok;
 }

--- a/src/bsgo/messages/SlotComponentMessage.hh
+++ b/src/bsgo/messages/SlotComponentMessage.hh
@@ -13,12 +13,12 @@ class SlotComponentMessage : public ComponentUpdatedMessage
   SlotComponentMessage(const Uuid playerDbId,
                        const Uuid shipDbId,
                        const int slotDbId,
-                       const std::optional<utils::Duration> &elapsedSinceLastFired);
+                       const std::optional<core::Duration> &elapsedSinceLastFired);
   ~SlotComponentMessage() override = default;
 
   auto getPlayerDbId() const -> Uuid;
   auto getSlotDbId() const -> Uuid;
-  auto getElapsedSinceLastFired() const -> std::optional<utils::Duration>;
+  auto getElapsedSinceLastFired() const -> std::optional<core::Duration>;
 
   auto serialize(std::ostream &out) const -> std::ostream & override;
   bool deserialize(std::istream &in) override;
@@ -28,7 +28,7 @@ class SlotComponentMessage : public ComponentUpdatedMessage
   private:
   Uuid m_playerDbId{};
   Uuid m_slotDbId{};
-  std::optional<utils::Duration> m_elapsedSinceLastFired{};
+  std::optional<core::Duration> m_elapsedSinceLastFired{};
 };
 
 } // namespace bsgo

--- a/src/bsgo/messages/SlotMessage.cc
+++ b/src/bsgo/messages/SlotMessage.cc
@@ -1,7 +1,7 @@
 
 
 #include "SlotMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -33,12 +33,12 @@ auto SlotMessage::getSlotType() const -> Slot
 
 auto SlotMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
 
-  utils::serialize(out, m_shipDbId);
-  utils::serialize(out, m_slotDbId);
-  utils::serialize(out, m_slotType);
+  core::serialize(out, m_shipDbId);
+  core::serialize(out, m_slotDbId);
+  core::serialize(out, m_slotType);
 
   return out;
 }
@@ -46,12 +46,12 @@ auto SlotMessage::serialize(std::ostream &out) const -> std::ostream &
 bool SlotMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_shipDbId);
-  ok &= utils::deserialize(in, m_slotDbId);
-  ok &= utils::deserialize(in, m_slotType);
+  ok &= core::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_slotDbId);
+  ok &= core::deserialize(in, m_slotType);
 
   return ok;
 }

--- a/src/bsgo/messages/TargetMessage.cc
+++ b/src/bsgo/messages/TargetMessage.cc
@@ -1,8 +1,8 @@
 
 
 #include "TargetMessage.hh"
+#include "SerializationUtils.hh"
 #include "VectorUtils.hh"
-#include <core_utils/SerializationUtils.hh>
 
 namespace bsgo {
 
@@ -47,14 +47,14 @@ auto TargetMessage::getTargetDbId() const -> std::optional<Uuid>
 
 auto TargetMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_shipDbId);
+  core::serialize(out, m_shipDbId);
   bsgo::serialize(out, m_position);
-  utils::serialize(out, m_targetKind);
-  utils::serialize(out, m_targetDbId);
+  core::serialize(out, m_targetKind);
+  core::serialize(out, m_targetDbId);
 
   return out;
 }
@@ -62,14 +62,14 @@ auto TargetMessage::serialize(std::ostream &out) const -> std::ostream &
 bool TargetMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_shipDbId);
   ok &= bsgo::deserialize(in, m_position);
-  ok &= utils::deserialize(in, m_targetKind);
-  ok &= utils::deserialize(in, m_targetDbId);
+  ok &= core::deserialize(in, m_targetKind);
+  ok &= core::deserialize(in, m_targetDbId);
 
   return ok;
 }

--- a/src/bsgo/messages/VelocityMessage.cc
+++ b/src/bsgo/messages/VelocityMessage.cc
@@ -1,8 +1,8 @@
 
 
 #include "VelocityMessage.hh"
+#include "SerializationUtils.hh"
 #include "VectorUtils.hh"
-#include <core_utils/SerializationUtils.hh>
 
 namespace bsgo {
 
@@ -28,11 +28,11 @@ auto VelocityMessage::getAcceleration() const -> Eigen::Vector3f
 
 auto VelocityMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
-  utils::serialize(out, m_validated);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+  core::serialize(out, m_validated);
 
-  utils::serialize(out, m_shipDbId);
+  core::serialize(out, m_shipDbId);
   bsgo::serialize(out, m_acceleration);
 
   return out;
@@ -41,11 +41,11 @@ auto VelocityMessage::serialize(std::ostream &out) const -> std::ostream &
 bool VelocityMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
-  ok &= utils::deserialize(in, m_validated);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_validated);
 
-  ok &= utils::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_shipDbId);
   ok &= bsgo::deserialize(in, m_acceleration);
 
   return ok;

--- a/src/bsgo/messages/WeaponComponentMessage.cc
+++ b/src/bsgo/messages/WeaponComponentMessage.cc
@@ -1,6 +1,6 @@
 
 #include "WeaponComponentMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 
 namespace bsgo {
 
@@ -30,13 +30,13 @@ bool WeaponComponentMessage::isActive() const
 
 auto WeaponComponentMessage::serialize(std::ostream &out) const -> std::ostream &
 {
-  utils::serialize(out, m_messageType);
-  utils::serialize(out, m_clientId);
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
 
-  utils::serialize(out, m_shipDbId);
-  utils::serialize(out, m_component);
-  utils::serialize(out, m_weaponDbId);
-  utils::serialize(out, m_active);
+  core::serialize(out, m_shipDbId);
+  core::serialize(out, m_component);
+  core::serialize(out, m_weaponDbId);
+  core::serialize(out, m_active);
 
   return out;
 }
@@ -44,13 +44,13 @@ auto WeaponComponentMessage::serialize(std::ostream &out) const -> std::ostream 
 bool WeaponComponentMessage::deserialize(std::istream &in)
 {
   bool ok{true};
-  ok &= utils::deserialize(in, m_messageType);
-  ok &= utils::deserialize(in, m_clientId);
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
 
-  ok &= utils::deserialize(in, m_shipDbId);
-  ok &= utils::deserialize(in, m_component);
-  ok &= utils::deserialize(in, m_weaponDbId);
-  ok &= utils::deserialize(in, m_active);
+  ok &= core::deserialize(in, m_shipDbId);
+  ok &= core::deserialize(in, m_component);
+  ok &= core::deserialize(in, m_weaponDbId);
+  ok &= core::deserialize(in, m_active);
 
   return ok;
 }

--- a/src/bsgo/queues/AsyncMessageQueue.cc
+++ b/src/bsgo/queues/AsyncMessageQueue.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 AsyncMessageQueue::AsyncMessageQueue(IMessageQueuePtr messageQueue)
-  : utils::CoreObject("async")
+  : core::CoreObject("async")
   , m_messageQueue(std::move(messageQueue))
 {
   addModule("queue");

--- a/src/bsgo/queues/AsyncMessageQueue.hh
+++ b/src/bsgo/queues/AsyncMessageQueue.hh
@@ -1,15 +1,15 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "IMessageQueue.hh"
 #include <atomic>
 #include <condition_variable>
-#include <core_utils/CoreObject.hh>
 #include <thread>
 
 namespace bsgo {
 
-class AsyncMessageQueue : public IMessageQueue, public utils::CoreObject
+class AsyncMessageQueue : public IMessageQueue, public core::CoreObject
 {
   public:
   AsyncMessageQueue(IMessageQueuePtr messageQueue);

--- a/src/bsgo/queues/MessageProcessor.hh
+++ b/src/bsgo/queues/MessageProcessor.hh
@@ -1,8 +1,8 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "IMessage.hh"
-#include <core_utils/CoreObject.hh>
 #include <deque>
 #include <functional>
 #include <mutex>
@@ -12,7 +12,7 @@ namespace bsgo {
 
 using MessageHandler = std::function<void(const IMessage &)>;
 
-class MessageProcessor : public utils::CoreObject
+class MessageProcessor : public core::CoreObject
 {
   public:
   MessageProcessor(const std::string &onBehalfOfName,

--- a/src/bsgo/queues/NetworkMessageQueue.cc
+++ b/src/bsgo/queues/NetworkMessageQueue.cc
@@ -6,7 +6,7 @@ namespace bsgo {
 
 NetworkMessageQueue::NetworkMessageQueue(IMessageQueuePtr synchronizedQueue)
   : IMessageQueue()
-  , utils::CoreObject("message")
+  , core::CoreObject("message")
   , m_synchronizedQueue(std::move(synchronizedQueue))
 {
   addModule("queue");

--- a/src/bsgo/queues/NetworkMessageQueue.hh
+++ b/src/bsgo/queues/NetworkMessageQueue.hh
@@ -2,15 +2,15 @@
 #pragma once
 
 #include "Connection.hh"
+#include "CoreObject.hh"
 #include "IMessageQueue.hh"
-#include <core_utils/CoreObject.hh>
 #include <deque>
 #include <memory>
 #include <vector>
 
 namespace bsgo {
 
-class NetworkMessageQueue : public IMessageQueue, public utils::CoreObject
+class NetworkMessageQueue : public IMessageQueue, public core::CoreObject
 {
   public:
   NetworkMessageQueue(IMessageQueuePtr synchronizedQueue);

--- a/src/bsgo/queues/SynchronizedMessageQueue.cc
+++ b/src/bsgo/queues/SynchronizedMessageQueue.cc
@@ -6,7 +6,7 @@ namespace bsgo {
 
 SynchronizedMessageQueue::SynchronizedMessageQueue(const std::string &name)
   : AbstractMessageQueue()
-  , utils::CoreObject(name)
+  , core::CoreObject(name)
 {
   setService("message");
 }

--- a/src/bsgo/queues/SynchronizedMessageQueue.hh
+++ b/src/bsgo/queues/SynchronizedMessageQueue.hh
@@ -2,15 +2,15 @@
 #pragma once
 
 #include "AbstractMessageQueue.hh"
+#include "CoreObject.hh"
 #include "IMessage.hh"
-#include <core_utils/CoreObject.hh>
 #include <deque>
 #include <mutex>
 #include <vector>
 
 namespace bsgo {
 
-class SynchronizedMessageQueue : public AbstractMessageQueue, public utils::CoreObject
+class SynchronizedMessageQueue : public AbstractMessageQueue, public core::CoreObject
 {
   public:
   SynchronizedMessageQueue(const std::string &name);

--- a/src/bsgo/repositories/ComputerRepository.cc
+++ b/src/bsgo/repositories/ComputerRepository.cc
@@ -69,10 +69,10 @@ auto ComputerRepository::fetchComputerBase(const Uuid computer) const -> Compute
   {
     out.range = {record[3].as<float>()};
   }
-  out.reloadTime = utils::Milliseconds(record[4].as<int>());
+  out.reloadTime = core::Milliseconds(record[4].as<int>());
   if (!record[5].is_null())
   {
-    out.duration = {utils::Milliseconds(record[5].as<int>())};
+    out.duration = {core::Milliseconds(record[5].as<int>())};
   }
   if (!record[6].is_null())
   {

--- a/src/bsgo/repositories/ComputerRepository.hh
+++ b/src/bsgo/repositories/ComputerRepository.hh
@@ -3,8 +3,8 @@
 
 #include "AbstractRepository.hh"
 #include "EntityKind.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 #include <optional>
 #include <unordered_set>
@@ -18,9 +18,9 @@ struct Computer
   bool offensive{};
   float powerCost{};
   std::optional<float> range{};
-  utils::Duration reloadTime{};
+  core::Duration reloadTime{};
 
-  std::optional<utils::Duration> duration{};
+  std::optional<core::Duration> duration{};
   std::optional<std::unordered_set<EntityKind>> allowedTargets{};
   std::optional<float> damageModifier{};
 };

--- a/src/bsgo/repositories/DbConnection.cc
+++ b/src/bsgo/repositories/DbConnection.cc
@@ -36,7 +36,7 @@ auto generateConnectionString() -> std::string
 } // namespace
 
 DbConnection::DbConnection()
-  : utils::CoreObject("connection")
+  : core::CoreObject("connection")
 {
   setService("db");
 }

--- a/src/bsgo/repositories/DbConnection.hh
+++ b/src/bsgo/repositories/DbConnection.hh
@@ -1,13 +1,13 @@
 
 #pragma once
 
-#include <core_utils/CoreObject.hh>
+#include "CoreObject.hh"
 #include <memory>
 #include <pqxx/pqxx>
 
 namespace bsgo {
 
-class DbConnection : public utils::CoreObject
+class DbConnection : public core::CoreObject
 {
   public:
   DbConnection();

--- a/src/bsgo/repositories/IRepository.cc
+++ b/src/bsgo/repositories/IRepository.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 IRepository::IRepository(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {
   setService("repository");
 }

--- a/src/bsgo/repositories/IRepository.hh
+++ b/src/bsgo/repositories/IRepository.hh
@@ -1,11 +1,11 @@
 
 #pragma once
 
-#include <core_utils/CoreObject.hh>
+#include "CoreObject.hh"
 
 namespace bsgo {
 
-class IRepository : public utils::CoreObject
+class IRepository : public core::CoreObject
 {
   public:
   IRepository(const std::string &name);

--- a/src/bsgo/repositories/PlayerComputerRepository.cc
+++ b/src/bsgo/repositories/PlayerComputerRepository.cc
@@ -94,10 +94,10 @@ auto PlayerComputerRepository::fetchComputerBase(const Uuid computer) const -> P
   {
     out.range = {record[5].as<float>()};
   }
-  out.reloadTime = utils::Milliseconds(record[6].as<int>());
+  out.reloadTime = core::Milliseconds(record[6].as<int>());
   if (!record[7].is_null())
   {
-    out.duration = {utils::Milliseconds(record[7].as<int>())};
+    out.duration = {core::Milliseconds(record[7].as<int>())};
   }
   if (!record[8].is_null())
   {

--- a/src/bsgo/repositories/PlayerComputerRepository.hh
+++ b/src/bsgo/repositories/PlayerComputerRepository.hh
@@ -3,8 +3,8 @@
 
 #include "AbstractRepository.hh"
 #include "EntityKind.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 #include <optional>
 #include <unordered_set>
@@ -23,9 +23,9 @@ struct PlayerComputer
   bool offensive{};
   float powerCost{};
   std::optional<float> range{};
-  utils::Duration reloadTime{};
+  core::Duration reloadTime{};
 
-  std::optional<utils::Duration> duration{};
+  std::optional<core::Duration> duration{};
   std::optional<std::unordered_set<EntityKind>> allowedTargets{};
   std::optional<float> damageModifier{};
 };

--- a/src/bsgo/repositories/PlayerShipRepository.cc
+++ b/src/bsgo/repositories/PlayerShipRepository.cc
@@ -255,8 +255,8 @@ auto PlayerShipRepository::fetchShipBase(const Uuid ship) const -> PlayerShip
     out.docked = record[19].as<bool>();
   }
 
-  out.jumpTime         = utils::Milliseconds(record[20].as<int>());
-  out.jumpTimeInThreat = utils::Milliseconds(record[21].as<int>());
+  out.jumpTime         = core::Milliseconds(record[20].as<int>());
+  out.jumpTimeInThreat = core::Milliseconds(record[21].as<int>());
   if (!record[22].is_null())
   {
     out.jumpSystem = fromDbId(record[22].as<int>());

--- a/src/bsgo/repositories/PlayerShipRepository.hh
+++ b/src/bsgo/repositories/PlayerShipRepository.hh
@@ -5,8 +5,8 @@
 #include "Faction.hh"
 #include "ShipClass.hh"
 #include "Slot.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/TimeUtils.hh>
 #include <eigen3/Eigen/Eigen>
 #include <memory>
 #include <optional>
@@ -42,8 +42,8 @@ struct PlayerShip
   std::optional<Uuid> system{};
   bool docked{};
 
-  utils::Duration jumpTime{};
-  utils::Duration jumpTimeInThreat{};
+  core::Duration jumpTime{};
+  core::Duration jumpTimeInThreat{};
   std::optional<Uuid> jumpSystem{};
 
   std::unordered_map<Slot, int> slots{};

--- a/src/bsgo/repositories/PlayerWeaponRepository.cc
+++ b/src/bsgo/repositories/PlayerWeaponRepository.cc
@@ -51,7 +51,7 @@ auto PlayerWeaponRepository::findOneById(const Uuid weapon) const -> PlayerWeapo
   out.maxDamage  = record[4].as<float>();
   out.powerCost  = record[5].as<float>();
   out.range      = record[6].as<float>();
-  out.reloadTime = utils::Milliseconds(record[7].as<int>());
+  out.reloadTime = core::Milliseconds(record[7].as<int>());
   out.level      = record[8].as<int>();
 
   return out;

--- a/src/bsgo/repositories/PlayerWeaponRepository.hh
+++ b/src/bsgo/repositories/PlayerWeaponRepository.hh
@@ -2,8 +2,8 @@
 #pragma once
 
 #include "AbstractRepository.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 #include <optional>
 #include <unordered_set>
@@ -26,7 +26,7 @@ struct PlayerWeapon
 
   float range{};
 
-  utils::Duration reloadTime{};
+  core::Duration reloadTime{};
 };
 
 class PlayerWeaponRepository : public AbstractRepository

--- a/src/bsgo/repositories/ResourceRepository.hh
+++ b/src/bsgo/repositories/ResourceRepository.hh
@@ -2,8 +2,8 @@
 #pragma once
 
 #include "AbstractRepository.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 
 namespace bsgo {

--- a/src/bsgo/repositories/ShipRepository.cc
+++ b/src/bsgo/repositories/ShipRepository.cc
@@ -57,8 +57,8 @@ auto fetchShipFromSqlResult(const pqxx::const_result_iterator &record) -> Ship
   ship.acceleration     = record[8].as<float>();
   ship.speed            = record[9].as<float>();
   ship.radius           = record[10].as<float>();
-  ship.jumpTime         = utils::Milliseconds(record[11].as<int>());
-  ship.jumpTimeInThreat = utils::Milliseconds(record[12].as<int>());
+  ship.jumpTime         = core::Milliseconds(record[11].as<int>());
+  ship.jumpTimeInThreat = core::Milliseconds(record[12].as<int>());
 
   return ship;
 }

--- a/src/bsgo/repositories/ShipRepository.hh
+++ b/src/bsgo/repositories/ShipRepository.hh
@@ -5,8 +5,8 @@
 #include "Faction.hh"
 #include "ShipClass.hh"
 #include "Slot.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 
 namespace bsgo {
@@ -29,8 +29,8 @@ struct Ship
 
   float radius{0.5f};
 
-  utils::Duration jumpTime{};
-  utils::Duration jumpTimeInThreat{};
+  core::Duration jumpTime{};
+  core::Duration jumpTimeInThreat{};
 
   std::unordered_map<Slot, int> slots{};
 };

--- a/src/bsgo/repositories/WeaponRepository.cc
+++ b/src/bsgo/repositories/WeaponRepository.cc
@@ -54,7 +54,7 @@ auto WeaponRepository::findOneById(const Uuid weapon) const -> Weapon
   out.maxDamage  = record[2].as<float>();
   out.powerCost  = record[3].as<float>();
   out.range      = record[4].as<float>();
-  out.reloadTime = utils::Milliseconds(record[5].as<int>());
+  out.reloadTime = core::Milliseconds(record[5].as<int>());
 
   return out;
 }

--- a/src/bsgo/repositories/WeaponRepository.hh
+++ b/src/bsgo/repositories/WeaponRepository.hh
@@ -2,8 +2,8 @@
 #pragma once
 
 #include "AbstractRepository.hh"
+#include "TimeUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 #include <unordered_set>
 
@@ -21,7 +21,7 @@ struct Weapon
 
   float range{};
 
-  utils::Duration reloadTime{};
+  core::Duration reloadTime{};
 };
 
 class WeaponRepository : public AbstractRepository

--- a/src/bsgo/services/IService.cc
+++ b/src/bsgo/services/IService.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 IService::IService(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {
   setService("service");
 }

--- a/src/bsgo/services/IService.hh
+++ b/src/bsgo/services/IService.hh
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <core_utils/CoreObject.hh>
+#include "CoreObject.hh"
 #include <memory>
 
 namespace bsgo {
@@ -14,7 +14,7 @@ enum class ProcessingMode
   CLIENT
 };
 
-class IService : public utils::CoreObject
+class IService : public core::CoreObject
 {
   public:
   IService(const std::string &name);

--- a/src/bsgo/systems/ComputerSystem.cc
+++ b/src/bsgo/systems/ComputerSystem.cc
@@ -120,7 +120,7 @@ void ComputerSystem::applyEmitterEffects(Entity &ent,
       error("Failed to activate computer", "Expected slot to define a duration");
     }
     debug("Adding weapon effect for " + ent.str() + " with duration "
-          + utils::durationToPrettyString(*duration, true));
+          + core::durationToPrettyString(*duration, true));
     coordinator.addWeaponEffect(ent.uuid, *duration, *damage);
   }
 }

--- a/src/bsgo/systems/ISystem.cc
+++ b/src/bsgo/systems/ISystem.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 ISystem::ISystem(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {
   setService("system");
 }

--- a/src/bsgo/systems/ISystem.hh
+++ b/src/bsgo/systems/ISystem.hh
@@ -2,16 +2,16 @@
 #pragma once
 
 #include "Components.hh"
+#include "CoreObject.hh"
 #include "IMessageQueue.hh"
 #include "SystemType.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 
 namespace bsgo {
 
 class Coordinator;
 
-class ISystem : public utils::CoreObject
+class ISystem : public core::CoreObject
 {
   public:
   ISystem(const std::string &name);

--- a/src/bsgo/systems/StatusSystem.cc
+++ b/src/bsgo/systems/StatusSystem.cc
@@ -15,8 +15,8 @@ StatusSystem::StatusSystem()
   : AbstractSystem(SystemType::STATUS, isEntityRelevant)
 {}
 
-constexpr auto TIME_TO_STAY_IN_APPEARED_MODE = utils::Milliseconds{10'000};
-constexpr auto TIME_TO_STAY_IN_THREAT_MODE   = utils::Milliseconds{3'000};
+constexpr auto TIME_TO_STAY_IN_APPEARED_MODE = core::Milliseconds{10'000};
+constexpr auto TIME_TO_STAY_IN_THREAT_MODE   = core::Milliseconds{3'000};
 
 void StatusSystem::updateEntity(Entity &entity,
                                 Coordinator &coordinator,
@@ -98,7 +98,7 @@ void StatusSystem::handleJumpState(Entity &entity,
   }
 
   const auto remaining = statusComp.tryGetRemainingJumpTime();
-  if (remaining >= utils::Duration{0})
+  if (remaining >= core::Duration{0})
   {
     return;
   }

--- a/src/bsgo/systems/tree/INode.cc
+++ b/src/bsgo/systems/tree/INode.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 INode::INode(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {
   setService("node");
 }

--- a/src/bsgo/systems/tree/INode.hh
+++ b/src/bsgo/systems/tree/INode.hh
@@ -1,16 +1,16 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "NodeState.hh"
 #include "TickData.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 
 namespace bsgo {
 
 /// https://www.gamedeveloper.com/programming/behavior-trees-for-ai-how-they-work
 /// https://en.wikipedia.org/wiki/Behavior_tree_(artificial_intelligence,_robotics_and_control)
-class INode : public utils::CoreObject
+class INode : public core::CoreObject
 {
   public:
   INode(const std::string &name);

--- a/src/bsgo/views/AbstractView.cc
+++ b/src/bsgo/views/AbstractView.cc
@@ -4,7 +4,7 @@
 namespace bsgo {
 
 AbstractView::AbstractView(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
   , IView()
 {
   setService("view");

--- a/src/bsgo/views/AbstractView.hh
+++ b/src/bsgo/views/AbstractView.hh
@@ -1,13 +1,13 @@
 
 #pragma once
 
+#include "CoreObject.hh"
 #include "IView.hh"
-#include <core_utils/CoreObject.hh>
 #include <string>
 
 namespace bsgo {
 
-class AbstractView : public utils::CoreObject, public IView
+class AbstractView : public core::CoreObject, public IView
 {
   public:
   AbstractView(const std::string &name);

--- a/src/bsgo/views/ShipView.hh
+++ b/src/bsgo/views/ShipView.hh
@@ -48,7 +48,7 @@ class ShipView : public AbstractView
   struct JumpData
   {
     std::string systemName{};
-    utils::Duration jumpTime{};
+    core::Duration jumpTime{};
   };
   auto getJumpData() const -> JumpData;
 

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories (bsgalone_client PUBLIC
 
 target_link_libraries (bsgalone_client PUBLIC
 	bsgalone-interface-library
-	core_utils
+	core_lib
 	client_lib
 	)
 

--- a/src/client/lib/CMakeLists.txt
+++ b/src/client/lib/CMakeLists.txt
@@ -32,7 +32,7 @@ target_sources (client_lib PRIVATE
 	)
 
 target_link_libraries (client_lib
-	core_utils
+	core_lib
 	pge_lib
 	bsgo_lib
 	)

--- a/src/client/lib/game/Game.cc
+++ b/src/client/lib/game/Game.cc
@@ -22,7 +22,7 @@
 namespace pge {
 
 Game::Game(const int serverPort)
-  : utils::CoreObject("game")
+  : core::CoreObject("game")
 {
   setService("game");
   initialize(serverPort);

--- a/src/client/lib/game/Game.hh
+++ b/src/client/lib/game/Game.hh
@@ -4,6 +4,7 @@
 #include "ClientMessageQueue.hh"
 #include "Context.hh"
 #include "Controls.hh"
+#include "CoreObject.hh"
 #include "DataSource.hh"
 #include "DatabaseEntityMapper.hh"
 #include "IInputHandler.hh"
@@ -14,7 +15,6 @@
 #include "RenderingPass.hh"
 #include "Screen.hh"
 #include "Views.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <unordered_map>
 
@@ -29,7 +29,7 @@ using IUiHandlerPtr = std::unique_ptr<IUiHandler>;
 class IInputHandler;
 using IInputHandlerPtr = std::unique_ptr<IInputHandler>;
 
-class Game : public utils::CoreObject
+class Game : public core::CoreObject
 {
   public:
   Game(const int serverPort);

--- a/src/client/lib/game/GameMessageModule.cc
+++ b/src/client/lib/game/GameMessageModule.cc
@@ -17,7 +17,7 @@ const Messages GAME_CHANGING_MESSAGE_TYPES = {bsgo::MessageType::CONNECTION,
 
 GameMessageModule::GameMessageModule(Game &game, const bsgo::DatabaseEntityMapper &entityMapper)
   : bsgo::AbstractMessageListener(GAME_CHANGING_MESSAGE_TYPES)
-  , utils::CoreObject("message")
+  , core::CoreObject("message")
   , m_game(game)
   , m_entityMapper(entityMapper)
 {

--- a/src/client/lib/game/GameMessageModule.hh
+++ b/src/client/lib/game/GameMessageModule.hh
@@ -2,8 +2,8 @@
 #pragma once
 
 #include "AbstractMessageListener.hh"
+#include "CoreObject.hh"
 #include "Uuid.hh"
-#include <core_utils/CoreObject.hh>
 #include <optional>
 
 #include "ConnectionMessage.hh"
@@ -20,7 +20,7 @@ namespace pge {
 
 class Game;
 
-class GameMessageModule : public bsgo::AbstractMessageListener, public utils::CoreObject
+class GameMessageModule : public bsgo::AbstractMessageListener, public core::CoreObject
 {
   public:
   GameMessageModule(Game &game, const bsgo::DatabaseEntityMapper &entityMapper);

--- a/src/client/lib/inputs/IInputHandler.cc
+++ b/src/client/lib/inputs/IInputHandler.cc
@@ -4,7 +4,7 @@
 namespace pge {
 
 IInputHandler::IInputHandler(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {
   setService("inputs");
 }

--- a/src/client/lib/inputs/IInputHandler.hh
+++ b/src/client/lib/inputs/IInputHandler.hh
@@ -3,12 +3,12 @@
 
 #include "Controls.hh"
 #include "CoordinateFrame.hh"
-#include <core_utils/CoreObject.hh>
+#include "CoreObject.hh"
 #include <memory>
 
 namespace pge {
 
-class IInputHandler : public utils::CoreObject
+class IInputHandler : public core::CoreObject
 {
   public:
   IInputHandler(const std::string &name);

--- a/src/client/lib/network/ClientConnection.cc
+++ b/src/client/lib/network/ClientConnection.cc
@@ -7,7 +7,7 @@ namespace pge {
 constexpr auto DEFAULT_SERVER_URL = "127.0.0.1";
 
 ClientConnection::ClientConnection(const int port, net::Context &networkContext)
-  : utils::CoreObject("connection")
+  : core::CoreObject("connection")
   , m_connection(networkContext.createConnection(DEFAULT_SERVER_URL, port))
 {
   setService("network");

--- a/src/client/lib/network/ClientConnection.hh
+++ b/src/client/lib/network/ClientConnection.hh
@@ -2,14 +2,14 @@
 #pragma once
 
 #include "Context.hh"
+#include "CoreObject.hh"
 #include "IMessage.hh"
 #include "IMessageQueue.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 
 namespace pge {
 
-class ClientConnection : public utils::CoreObject
+class ClientConnection : public core::CoreObject
 {
   public:
   ClientConnection(const int port, net::Context &networkContext);

--- a/src/client/lib/network/ClientMessageQueue.cc
+++ b/src/client/lib/network/ClientMessageQueue.cc
@@ -6,7 +6,7 @@
 namespace pge {
 
 ClientMessageQueue::ClientMessageQueue(ClientConnectionPtr connection)
-  : utils::CoreObject("message")
+  : core::CoreObject("message")
   , m_connection(std::move(connection))
 {
   addModule("queue");

--- a/src/client/lib/network/ClientMessageQueue.hh
+++ b/src/client/lib/network/ClientMessageQueue.hh
@@ -2,15 +2,15 @@
 #pragma once
 
 #include "ClientConnection.hh"
+#include "CoreObject.hh"
 #include "IMessageQueue.hh"
 #include "Uuid.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <optional>
 
 namespace pge {
 
-class ClientMessageQueue : public bsgo::IMessageQueue, public utils::CoreObject
+class ClientMessageQueue : public bsgo::IMessageQueue, public core::CoreObject
 {
   public:
   ClientMessageQueue(ClientConnectionPtr connection);

--- a/src/client/lib/renderers/IRenderer.cc
+++ b/src/client/lib/renderers/IRenderer.cc
@@ -4,7 +4,7 @@
 namespace pge {
 
 IRenderer::IRenderer(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {
   setService("renderer");
 }

--- a/src/client/lib/renderers/IRenderer.hh
+++ b/src/client/lib/renderers/IRenderer.hh
@@ -2,15 +2,15 @@
 #pragma once
 
 #include "CoordinateFrame.hh"
+#include "CoreObject.hh"
 #include "RenderState.hh"
 #include "Renderer.hh"
 #include "RenderingPass.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 
 namespace pge {
 
-class IRenderer : public utils::CoreObject
+class IRenderer : public core::CoreObject
 {
   public:
   IRenderer(const std::string &name);

--- a/src/client/lib/ui/IUiHandler.cc
+++ b/src/client/lib/ui/IUiHandler.cc
@@ -4,7 +4,7 @@
 namespace pge {
 
 IUiHandler::IUiHandler(const std::string &name)
-  : utils::CoreObject(name)
+  : core::CoreObject(name)
 {}
 
 void IUiHandler::reset()

--- a/src/client/lib/ui/IUiHandler.hh
+++ b/src/client/lib/ui/IUiHandler.hh
@@ -3,15 +3,15 @@
 
 #include "Controls.hh"
 #include "CoordinateFrame.hh"
+#include "CoreObject.hh"
 #include "Game.hh"
 #include "IMessageQueue.hh"
 #include "UserInputData.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 
 namespace pge {
 
-class IUiHandler : public utils::CoreObject
+class IUiHandler : public core::CoreObject
 {
   public:
   IUiHandler(const std::string &name);

--- a/src/client/lib/ui/common/ShipItemUtils.cc
+++ b/src/client/lib/ui/common/ShipItemUtils.cc
@@ -2,15 +2,15 @@
 #include "ShipItemUtils.hh"
 #include "ScreenCommon.hh"
 #include "StringUtils.hh"
-#include <core_utils/TimeUtils.hh>
+#include "TimeUtils.hh"
 
 namespace pge {
 
 constexpr auto MILLISECONDS_IN_A_SECOND = 1000.0f;
 
-auto durationToSeconds(const utils::Duration &duration) -> float
+auto durationToSeconds(const core::Duration &duration) -> float
 {
-  return utils::toMilliseconds(duration) / MILLISECONDS_IN_A_SECOND;
+  return core::toMilliseconds(duration) / MILLISECONDS_IN_A_SECOND;
 }
 
 auto generateTextConfig(const std::string &name, const Color &color, const int margin) -> TextConfig
@@ -22,7 +22,7 @@ auto generateWeaponMenu(const std::string &name,
                         const float minDamage,
                         const float maxDamage,
                         const float range,
-                        const utils::Duration reloadTime) -> UiMenuPtr
+                        const core::Duration reloadTime) -> UiMenuPtr
 {
   auto menu = generateBlankVerticalMenu();
 
@@ -74,8 +74,8 @@ auto generateWeaponMenu(const bsgo::PlayerWeapon &weapon) -> UiMenuPtr
 auto generateComputerMenu(const std::string &name,
                           const float powerCost,
                           const std::optional<float> &range,
-                          const std::optional<utils::Duration> &duration,
-                          const utils::Duration &reloadTime) -> UiMenuPtr
+                          const std::optional<core::Duration> &duration,
+                          const core::Duration &reloadTime) -> UiMenuPtr
 {
   auto menu = generateBlankVerticalMenu();
 
@@ -110,7 +110,7 @@ auto generateComputerMenu(const std::string &name,
   }
 
   constexpr auto MILLISECONDS_IN_A_SECOND = 1000.0f;
-  const auto secondsToReload = utils::toMilliseconds(reloadTime) / MILLISECONDS_IN_A_SECOND;
+  const auto secondsToReload = core::toMilliseconds(reloadTime) / MILLISECONDS_IN_A_SECOND;
   label                      = "Reload: " + bsgo::floatToStr(secondsToReload, 2) + "s";
   text                       = generateTextConfig(label);
   prop                       = std::make_unique<UiTextMenu>(config, bg, text);

--- a/src/client/lib/ui/game/LogUiHandler.cc
+++ b/src/client/lib/ui/game/LogUiHandler.cc
@@ -142,9 +142,9 @@ void LogUiHandler::onMessageReceived(const bsgo::IMessage &message)
   LogMessage data{};
   data.rawMenu = logMenu.get();
 
-  TimedMenuConfig timedConfig{.duration          = utils::Milliseconds(LOG_FADE_OUT_DURATION_MS),
+  TimedMenuConfig timedConfig{.duration          = core::Milliseconds(LOG_FADE_OUT_DURATION_MS),
                               .fadeOut           = true,
-                              .fadeOutDuration   = utils::Milliseconds(LOG_FADE_OUT_DURATION_MS),
+                              .fadeOutDuration   = core::Milliseconds(LOG_FADE_OUT_DURATION_MS),
                               .applyToBackGround = false};
   data.menu = std::make_unique<UiTimedMenu>(timedConfig, std::move(logMenu));
 

--- a/src/client/lib/ui/game/ShipStatusUiHandler.cc
+++ b/src/client/lib/ui/game/ShipStatusUiHandler.cc
@@ -69,7 +69,7 @@ void ShipStatusUiHandler::onMessageReceived(const bsgo::IMessage &message)
 
   if (bsgo::MessageType::JUMP_REQUESTED == message.type())
   {
-    m_jumpStartTime = utils::now();
+    m_jumpStartTime = core::now();
   }
   if (bsgo::MessageType::JUMP_CANCELLED == message.type())
   {
@@ -169,10 +169,10 @@ void ShipStatusUiHandler::updateJumpPanel()
   const auto data = m_shipView->getJumpData();
   m_jumpDestination->setText(data.systemName);
 
-  const auto elapsedSinceJumpStarted = utils::now() - *m_jumpStartTime;
+  const auto elapsedSinceJumpStarted = core::now() - *m_jumpStartTime;
   const auto remainingJumpTime       = data.jumpTime - elapsedSinceJumpStarted;
 
-  m_jumpTime->setText(utils::durationToPrettyString(remainingJumpTime));
+  m_jumpTime->setText(core::durationToPrettyString(remainingJumpTime));
 }
 
 } // namespace pge

--- a/src/client/lib/ui/game/ShipStatusUiHandler.hh
+++ b/src/client/lib/ui/game/ShipStatusUiHandler.hh
@@ -3,9 +3,9 @@
 
 #include "AbstractMessageListener.hh"
 #include "IUiHandler.hh"
+#include "TimeUtils.hh"
 #include "UiBlinkingMenu.hh"
 #include "UiTextMenu.hh"
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 
 namespace pge {
@@ -36,7 +36,7 @@ class ShipStatusUiHandler : public IUiHandler, public bsgo::AbstractMessageListe
   UiTextMenu *m_jumpDestination{};
   UiTextMenu *m_jumpTime{};
 
-  std::optional<utils::TimeStamp> m_jumpStartTime{};
+  std::optional<core::TimeStamp> m_jumpStartTime{};
 
   void initializeThreatPanel(const int width, const int height);
   void initializeJumpPanel(const int width, const int height);

--- a/src/client/lib/ui/menus/UiBlinkingMenu.cc
+++ b/src/client/lib/ui/menus/UiBlinkingMenu.cc
@@ -9,7 +9,7 @@ UiBlinkingMenu::UiBlinkingMenu(UiMenuPtr menu)
 {}
 
 UiBlinkingMenu::UiBlinkingMenu(const BlinkingMenuConfig &config, UiMenuPtr menu)
-  : utils::CoreObject("blinking")
+  : core::CoreObject("blinking")
   , m_menu(std::move(menu))
 {
   setService("menu");
@@ -41,7 +41,7 @@ void UiBlinkingMenu::setVisible(const bool visible)
     return;
   }
 
-  m_lastTrigger   = utils::now();
+  m_lastTrigger   = core::now();
   m_blinkingState = State::FADE_OUT;
 }
 
@@ -52,7 +52,7 @@ void UiBlinkingMenu::update()
     return;
   }
 
-  const auto now     = utils::now();
+  const auto now     = core::now();
   const auto elapsed = now - *m_lastTrigger;
   handleBlinking(now);
 
@@ -76,7 +76,7 @@ void UiBlinkingMenu::initializeFromConfig(const BlinkingMenuConfig &config)
   m_applyToText       = config.applyToText;
 }
 
-void UiBlinkingMenu::handleBlinking(const utils::TimeStamp &now)
+void UiBlinkingMenu::handleBlinking(const core::TimeStamp &now)
 {
   const auto fadeElapsedTimeAsFloat = std::chrono::duration<float, std::milli>(now - *m_lastTrigger);
 

--- a/src/client/lib/ui/menus/UiBlinkingMenu.hh
+++ b/src/client/lib/ui/menus/UiBlinkingMenu.hh
@@ -1,22 +1,22 @@
 
 #pragma once
 
+#include "CoreObject.hh"
+#include "TimeUtils.hh"
 #include "UiMenu.hh"
-#include <core_utils/CoreObject.hh>
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 
 namespace pge {
 
 struct BlinkingMenuConfig
 {
-  utils::Duration blinkingDuration{utils::Milliseconds(1500)};
+  core::Duration blinkingDuration{core::Milliseconds(1500)};
 
   bool applyToBackground{true};
   bool applyToText{true};
 };
 
-class UiBlinkingMenu : public utils::CoreObject
+class UiBlinkingMenu : public core::CoreObject
 {
   public:
   UiBlinkingMenu(UiMenuPtr menu);
@@ -30,7 +30,7 @@ class UiBlinkingMenu : public utils::CoreObject
 
   private:
   UiMenuPtr m_menu{};
-  utils::Duration m_blinkingDuration{};
+  core::Duration m_blinkingDuration{};
   bool m_applyToBackground{true};
   bool m_applyToText{true};
 
@@ -41,10 +41,10 @@ class UiBlinkingMenu : public utils::CoreObject
   };
 
   State m_blinkingState{State::FADE_OUT};
-  std::optional<utils::TimeStamp> m_lastTrigger{};
+  std::optional<core::TimeStamp> m_lastTrigger{};
 
   void initializeFromConfig(const BlinkingMenuConfig &config);
-  void handleBlinking(const utils::TimeStamp &now);
+  void handleBlinking(const core::TimeStamp &now);
   void updateOpacity(const float perc);
 };
 

--- a/src/client/lib/ui/menus/UiMenu.cc
+++ b/src/client/lib/ui/menus/UiMenu.cc
@@ -4,7 +4,7 @@
 namespace pge {
 
 UiMenu::UiMenu(const MenuConfig &config, const BackgroundConfig &bg)
-  : utils::CoreObject("menu")
+  : core::CoreObject("menu")
   , m_bg(bg)
 {
   initializeFromConfig(config);

--- a/src/client/lib/ui/menus/UiMenu.hh
+++ b/src/client/lib/ui/menus/UiMenu.hh
@@ -3,9 +3,9 @@
 
 #include "BackgroundConfig.hh"
 #include "Controls.hh"
+#include "CoreObject.hh"
 #include "MenuConfig.hh"
 #include "Renderer.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <optional>
 
@@ -14,7 +14,7 @@ namespace pge {
 class UiMenu;
 using UiMenuPtr = std::unique_ptr<UiMenu>;
 
-class UiMenu : public utils::CoreObject
+class UiMenu : public core::CoreObject
 {
   public:
   UiMenu(const MenuConfig &config, const BackgroundConfig &bg);

--- a/src/client/lib/ui/menus/UiTimedMenu.cc
+++ b/src/client/lib/ui/menus/UiTimedMenu.cc
@@ -9,7 +9,7 @@ UiTimedMenu::UiTimedMenu(UiMenuPtr menu)
 {}
 
 UiTimedMenu::UiTimedMenu(const TimedMenuConfig &config, UiMenuPtr menu)
-  : utils::CoreObject("timed")
+  : core::CoreObject("timed")
   , m_menu(std::move(menu))
 {
   setService("menu");
@@ -28,7 +28,7 @@ void UiTimedMenu::trigger()
   m_menu->setVisible(true);
   updateOpacity(1.0f);
 
-  m_lastTrigger = utils::now();
+  m_lastTrigger = core::now();
   if (m_fadeOutDuration)
   {
     m_fadeOutStartTime = *m_lastTrigger + m_duration - *m_fadeOutDuration;
@@ -42,7 +42,7 @@ void UiTimedMenu::update()
     return;
   }
 
-  const auto now     = utils::now();
+  const auto now     = core::now();
   const auto elapsed = now - *m_lastTrigger;
   handleFadeOut(now);
 
@@ -79,7 +79,7 @@ void UiTimedMenu::initializeFromConfig(const TimedMenuConfig &config)
   m_applyToBackGround = config.applyToBackGround;
 }
 
-void UiTimedMenu::handleFadeOut(const utils::TimeStamp &now)
+void UiTimedMenu::handleFadeOut(const core::TimeStamp &now)
 {
   if (!m_fadeOutStartTime || now < *m_fadeOutStartTime)
   {

--- a/src/client/lib/ui/menus/UiTimedMenu.hh
+++ b/src/client/lib/ui/menus/UiTimedMenu.hh
@@ -1,23 +1,23 @@
 
 #pragma once
 
+#include "CoreObject.hh"
+#include "TimeUtils.hh"
 #include "UiMenu.hh"
-#include <core_utils/CoreObject.hh>
-#include <core_utils/TimeUtils.hh>
 #include <memory>
 
 namespace pge {
 
 struct TimedMenuConfig
 {
-  utils::Duration duration{utils::Milliseconds(1500)};
+  core::Duration duration{core::Milliseconds(1500)};
 
   bool fadeOut{true};
-  utils::Duration fadeOutDuration{utils::Milliseconds(1000)};
+  core::Duration fadeOutDuration{core::Milliseconds(1000)};
   bool applyToBackGround{true};
 };
 
-class UiTimedMenu : public utils::CoreObject
+class UiTimedMenu : public core::CoreObject
 {
   public:
   UiTimedMenu(UiMenuPtr menu);
@@ -33,15 +33,15 @@ class UiTimedMenu : public utils::CoreObject
 
   private:
   UiMenuPtr m_menu{};
-  utils::Duration m_duration{};
-  std::optional<utils::Duration> m_fadeOutDuration{};
+  core::Duration m_duration{};
+  std::optional<core::Duration> m_fadeOutDuration{};
   bool m_applyToBackGround{true};
 
-  std::optional<utils::TimeStamp> m_lastTrigger{};
-  std::optional<utils::TimeStamp> m_fadeOutStartTime{};
+  std::optional<core::TimeStamp> m_lastTrigger{};
+  std::optional<core::TimeStamp> m_fadeOutStartTime{};
 
   void initializeFromConfig(const TimedMenuConfig &config);
-  void handleFadeOut(const utils::TimeStamp &now);
+  void handleFadeOut(const core::TimeStamp &now);
   void updateOpacity(const float perc);
 };
 

--- a/src/client/main.cc
+++ b/src/client/main.cc
@@ -3,11 +3,11 @@
 
 #include "App.hh"
 #include "AppDesc.hh"
+#include "CoreException.hh"
 #include "TopViewFrame.hh"
-#include <core_utils/CoreException.hh>
-#include <core_utils/log/Locator.hh>
-#include <core_utils/log/PrefixedLogger.hh>
-#include <core_utils/log/StdLogger.hh>
+#include "log/Locator.hh"
+#include "log/PrefixedLogger.hh"
+#include "log/StdLogger.hh"
 
 namespace {
 auto getPortFromEnvironmentVariable() -> int
@@ -52,10 +52,10 @@ auto getPortFromEnvironmentVariable() -> int
 int main(int /*argc*/, char ** /*argv*/)
 {
   // Create the logger.
-  utils::log::StdLogger raw;
-  raw.setLevel(utils::log::Severity::DEBUG);
-  utils::log::PrefixedLogger logger("client", "main");
-  utils::log::Locator::provide(&raw);
+  core::log::StdLogger raw;
+  raw.setLevel(core::log::Severity::DEBUG);
+  core::log::PrefixedLogger logger("client", "main");
+  core::log::Locator::provide(&raw);
 
   try
   {
@@ -73,7 +73,7 @@ int main(int /*argc*/, char ** /*argv*/)
 
     demo.run();
   }
-  catch (const utils::CoreException &e)
+  catch (const core::CoreException &e)
   {
     logger.error("Caught internal exception while setting up application", e.what());
     return EXIT_FAILURE;

--- a/src/core/SerializationUtils.hh
+++ b/src/core/SerializationUtils.hh
@@ -1,0 +1,44 @@
+
+#pragma once
+
+#include <istream>
+#include <optional>
+#include <ostream>
+#include <type_traits>
+
+namespace core {
+
+/// https://stackoverflow.com/questions/55647741/template-specialization-with-enable-if
+/// https://en.cppreference.com/w/cpp/types/enable_if
+
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+auto serialize(std::ostream &out, const T &e) -> std::ostream &;
+
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+auto serialize(std::ostream &out, const T &e) -> std::ostream &;
+
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+bool deserialize(std::istream &in, T &e);
+
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+bool deserialize(std::istream &in, T &e);
+
+auto serialize(std::ostream &out, const std::string &str) -> std::ostream &;
+
+bool deserialize(std::istream &in, std::string &str);
+
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+auto serialize(std::ostream &out, const std::optional<T> &value) -> std::ostream &;
+
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+auto serialize(std::ostream &out, const std::optional<T> &value) -> std::ostream &;
+
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+bool deserialize(std::istream &in, std::optional<T> &value);
+
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+bool deserialize(std::istream &in, std::optional<T> &value);
+
+} // namespace core
+
+#include "SerializationUtils.hxx"

--- a/src/core/SerializationUtils.hxx
+++ b/src/core/SerializationUtils.hxx
@@ -1,0 +1,134 @@
+
+#pragma once
+
+#include "SerializationUtils.hh"
+
+namespace core {
+
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+inline auto serialize(std::ostream &out, const T &e) -> std::ostream &
+{
+  const auto eAsChar = reinterpret_cast<const char *>(&e);
+  const auto size    = sizeof(typename std::underlying_type<T>::type);
+  out.write(eAsChar, size);
+
+  return out;
+}
+
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+inline auto serialize(std::ostream &out, const T &value) -> std::ostream &
+{
+  const auto valueAsChar = reinterpret_cast<const char *>(&value);
+  const auto size        = sizeof(T);
+  out.write(valueAsChar, size);
+
+  return out;
+}
+
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+inline bool deserialize(std::istream &in, T &e)
+{
+  const auto eAsChar = reinterpret_cast<char *>(&e);
+  const auto size    = sizeof(typename std::underlying_type<T>::type);
+  in.read(eAsChar, size);
+
+  return in.good();
+}
+
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+inline bool deserialize(std::istream &in, T &value)
+{
+  const auto valueAsChar = reinterpret_cast<char *>(&value);
+  const auto size        = sizeof(T);
+  in.read(valueAsChar, size);
+
+  return in.good();
+}
+
+inline auto serialize(std::ostream &out, const std::string &str) -> std::ostream &
+{
+  const std::size_t size{str.size()};
+  out.write(reinterpret_cast<const char *>(&size), sizeof(std::size_t));
+  if (!str.empty())
+  {
+    out << str;
+  }
+
+  return out;
+}
+
+inline bool deserialize(std::istream &in, std::string &str)
+{
+  std::size_t size{};
+  in.read(reinterpret_cast<char *>(&size), sizeof(std::size_t));
+  str.resize(size);
+  in.read(str.data(), size);
+
+  return in.good();
+}
+
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+inline auto serialize(std::ostream &out, const std::optional<T> &value) -> std::ostream &
+{
+  const auto hasValue = value.has_value();
+  out.write(reinterpret_cast<const char *>(&hasValue), sizeof(bool));
+  if (hasValue)
+  {
+    serialize(out, *value);
+  }
+
+  return out;
+}
+
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+inline auto serialize(std::ostream &out, const std::optional<T> &value) -> std::ostream &
+{
+  const auto hasValue = value.has_value();
+  out.write(reinterpret_cast<const char *>(&hasValue), sizeof(bool));
+  if (hasValue)
+  {
+    serialize(out, *value);
+  }
+
+  return out;
+}
+
+template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+inline bool deserialize(std::istream &in, std::optional<T> &value)
+{
+  bool hasValue{false};
+  in.read(reinterpret_cast<char *>(&hasValue), sizeof(bool));
+  if (hasValue)
+  {
+    T raw{};
+    deserialize(in, raw);
+    value = raw;
+  }
+  else
+  {
+    value.reset();
+  }
+
+  return in.good();
+}
+
+template<typename T, std::enable_if_t<!std::is_enum<T>::value, bool> = true>
+inline bool deserialize(std::istream &in, std::optional<T> &value)
+{
+  bool hasValue{false};
+  in.read(reinterpret_cast<char *>(&hasValue), sizeof(bool));
+  if (hasValue)
+  {
+    T raw{};
+    deserialize(in, raw);
+    value = raw;
+  }
+  else
+  {
+    value.reset();
+  }
+
+  return in.good();
+}
+
+} // namespace core

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories (net_lib PUBLIC
 
 target_link_libraries (net_lib PUBLIC
 	bsgalone-interface-library
+	core_lib
 	)
 
 if (${ENABLE_TESTS})

--- a/src/net/connection/Connection.cc
+++ b/src/net/connection/Connection.cc
@@ -21,7 +21,7 @@ Connection::Connection(asio::ip::tcp::socket &&socket)
 {}
 
 Connection::Connection(asio::ip::tcp::socket &&socket, const ConnectionType type)
-  : utils::CoreObject("connection")
+  : core::CoreObject("connection")
   , m_id(NEXT_ID.fetch_add(1))
   , m_type(type)
   , m_socket(std::move(socket))

--- a/src/net/connection/Connection.hh
+++ b/src/net/connection/Connection.hh
@@ -2,9 +2,9 @@
 #pragma once
 
 #include "ConnectionType.hh"
+#include "CoreObject.hh"
 #include <asio.hpp>
 #include <atomic>
-#include <core_utils/CoreObject.hh>
 #include <deque>
 #include <memory>
 #include <optional>
@@ -16,7 +16,7 @@ using ConnectionId        = int;
 using DataReceivedHandler = std::function<int(const ConnectionId, const std::deque<char> &)>;
 using DisconnectHandler   = std::function<void(const ConnectionId)>;
 
-class Connection : public utils::CoreObject, public std::enable_shared_from_this<Connection>
+class Connection : public core::CoreObject, public std::enable_shared_from_this<Connection>
 {
   public:
   Connection(const std::string &url, const int port, asio::io_context &context);

--- a/src/net/connection/Context.cc
+++ b/src/net/connection/Context.cc
@@ -1,11 +1,11 @@
 
 #include "Context.hh"
-#include <core_utils/TimeUtils.hh>
+#include "TimeUtils.hh"
 
 namespace net {
 
 Context::Context()
-  : utils::CoreObject("context")
+  : core::CoreObject("context")
 {
   setService("net");
 }

--- a/src/net/connection/Context.hh
+++ b/src/net/connection/Context.hh
@@ -2,16 +2,16 @@
 #pragma once
 
 #include "Connection.hh"
+#include "CoreObject.hh"
 #include <asio.hpp>
 #include <atomic>
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <mutex>
 #include <thread>
 
 namespace net {
 
-class Context : public utils::CoreObject
+class Context : public core::CoreObject
 {
   public:
   Context();

--- a/src/net/server/TcpServer.cc
+++ b/src/net/server/TcpServer.cc
@@ -5,7 +5,7 @@
 namespace net {
 
 TcpServer::TcpServer(Context &context, const int port, const ServerConfig &config)
-  : utils::CoreObject("tcp")
+  : core::CoreObject("tcp")
   , m_port(port)
   , m_asioAcceptor(context.get(), asio::ip::tcp::endpoint(asio::ip::tcp::v4(), m_port))
 {

--- a/src/net/server/TcpServer.hh
+++ b/src/net/server/TcpServer.hh
@@ -3,9 +3,9 @@
 
 #include "Connection.hh"
 #include "Context.hh"
+#include "CoreObject.hh"
 #include "ServerConfig.hh"
 #include <asio.hpp>
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -13,7 +13,7 @@
 
 namespace net {
 
-class TcpServer : public utils::CoreObject, public std::enable_shared_from_this<TcpServer>
+class TcpServer : public core::CoreObject, public std::enable_shared_from_this<TcpServer>
 {
   public:
   TcpServer(Context &context, const int port, const ServerConfig &config);

--- a/src/pge/CMakeLists.txt
+++ b/src/pge/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries (pge_lib PUBLIC
 	X11
 	GL
 	pthread
+	core_lib
 	)
 
 if (${ENABLE_TESTS})

--- a/src/pge/app/FramerateControl.cc
+++ b/src/pge/app/FramerateControl.cc
@@ -4,15 +4,15 @@
 
 namespace pge {
 
-constexpr auto MIN_SLEEP_TIME           = utils::Milliseconds(5);
+constexpr auto MIN_SLEEP_TIME           = core::Milliseconds(5);
 constexpr auto MILLISECONDS_IN_A_SECOND = 1'000;
 
 FramerateControl::FramerateControl(int maxFps)
-  : utils::CoreObject("control")
+  : core::CoreObject("control")
   , m_maxFps(maxFps)
 {
   setService("fps");
-  m_sleepTimeInMs    = utils::Milliseconds(MILLISECONDS_IN_A_SECOND / maxFps);
+  m_sleepTimeInMs    = core::Milliseconds(MILLISECONDS_IN_A_SECOND / maxFps);
   m_minSleepTimeInMs = MIN_SLEEP_TIME;
 }
 
@@ -20,17 +20,17 @@ void FramerateControl::throttle()
 {
   if (!m_lastThrottlingTime)
   {
-    m_lastThrottlingTime = utils::now();
+    m_lastThrottlingTime = core::now();
     return;
   }
 
-  const auto now     = utils::now();
+  const auto now     = core::now();
   const auto elapsed = now - *m_lastThrottlingTime;
 
   if (elapsed > m_sleepTimeInMs)
   {
     m_lastThrottlingTime = now;
-    m_sleepDriftInMs     = utils::Milliseconds(0);
+    m_sleepDriftInMs     = core::Milliseconds(0);
     return;
   }
 
@@ -49,7 +49,7 @@ void FramerateControl::throttle()
 
   std::this_thread::sleep_for(sleepTime);
 
-  m_lastThrottlingTime = utils::now();
+  m_lastThrottlingTime = core::now();
   m_sleepDriftInMs     = leftoverSleepTime;
 }
 

--- a/src/pge/app/FramerateControl.hh
+++ b/src/pge/app/FramerateControl.hh
@@ -1,13 +1,13 @@
 
 #pragma once
 
-#include <core_utils/CoreObject.hh>
-#include <core_utils/TimeUtils.hh>
+#include "CoreObject.hh"
+#include "TimeUtils.hh"
 #include <optional>
 
 namespace pge {
 
-class FramerateControl : public utils::CoreObject
+class FramerateControl : public core::CoreObject
 {
   public:
   FramerateControl(int maxFps);
@@ -22,20 +22,20 @@ class FramerateControl : public utils::CoreObject
 
   /// @brief - The maximum duration that each frame should take to maintain
   /// the desired maximum framerate in milliseconds.
-  utils::Duration m_sleepTimeInMs;
+  core::Duration m_sleepTimeInMs;
 
   /// @brief - A minimum duration to still consider that it's worth it to
   /// throttle the calling thread. If the remaining duration to wait is
   /// smaller than this we consider that it's a close enough approximation
   /// of the maximum framerate.
-  utils::Duration m_minSleepTimeInMs;
+  core::Duration m_minSleepTimeInMs;
 
   /// @brief - The drift accumulated by not sleeping for too short duration.
-  utils::Duration m_sleepDriftInMs{};
+  core::Duration m_sleepDriftInMs{};
 
   /// @brief - The last time point we have where we applied throttling. If
   /// empty we never applied throttling.
-  std::optional<utils::TimeStamp> m_lastThrottlingTime{};
+  std::optional<core::TimeStamp> m_lastThrottlingTime{};
 };
 
 } // namespace pge

--- a/src/pge/app/PGEApp.cc
+++ b/src/pge/app/PGEApp.cc
@@ -6,7 +6,7 @@
 namespace pge {
 
 PGEApp::PGEApp(const AppDesc &desc)
-  : utils::CoreObject(desc.name)
+  : core::CoreObject(desc.name)
   , m_fixedFrame(desc.fixedFrame)
   , m_frame(desc.frame)
 {

--- a/src/pge/app/PGEApp.hh
+++ b/src/pge/app/PGEApp.hh
@@ -5,10 +5,10 @@
 #include "Color.hh"
 #include "Controls.hh"
 #include "CoordinateFrame.hh"
+#include "CoreObject.hh"
 #include "FramerateControl.hh"
 #include "RenderState.hh"
 #include "Renderer.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <optional>
 
@@ -18,7 +18,7 @@ class PixelGameEngine;
 
 namespace pge {
 
-class PGEApp : public utils::CoreObject
+class PGEApp : public core::CoreObject
 {
   public:
   /// @brief - Create a new default pixel game engine app.

--- a/src/pge/coordinates/CoordinateFrame.cc
+++ b/src/pge/coordinates/CoordinateFrame.cc
@@ -4,7 +4,7 @@
 namespace pge {
 
 CoordinateFrame::CoordinateFrame(const CenteredViewport &tiles, const TopLeftViewport &pixels)
-  : utils::CoreObject("frame")
+  : core::CoreObject("frame")
   , m_tilesViewport(tiles)
   , m_pixelsViewport(pixels)
 {

--- a/src/pge/coordinates/CoordinateFrame.hh
+++ b/src/pge/coordinates/CoordinateFrame.hh
@@ -2,13 +2,13 @@
 #pragma once
 
 #include "CenteredViewport.hh"
+#include "CoreObject.hh"
 #include "TopLeftViewport.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 
 namespace pge {
 
-class CoordinateFrame : public utils::CoreObject
+class CoordinateFrame : public core::CoreObject
 {
   public:
   /// @brief - Creates a new coordinate frame with the input pixel

--- a/src/pge/sprites/TexturePack.cc
+++ b/src/pge/sprites/TexturePack.cc
@@ -14,7 +14,7 @@ auto TexturePack::Pack::spriteCoords(const Vec2i &coord, int id) const -> Vec2i
 }
 
 TexturePack::TexturePack(olc::PixelGameEngine *const engine)
-  : utils::CoreObject("pack")
+  : core::CoreObject("pack")
   , m_packs()
   , m_engine(engine)
 {

--- a/src/pge/sprites/TexturePack.hh
+++ b/src/pge/sprites/TexturePack.hh
@@ -2,9 +2,9 @@
 #pragma once
 
 #include "Color.hh"
+#include "CoreObject.hh"
 #include "DecalResource.hh"
 #include "Vector2d.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 
 namespace olc {
@@ -56,7 +56,7 @@ struct Sprite
   Color tint{colors::WHITE};
 };
 
-class TexturePack : public utils::CoreObject
+class TexturePack : public core::CoreObject
 {
   public:
   TexturePack(olc::PixelGameEngine *const engine);

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories (bsgalone_server PUBLIC
 
 target_link_libraries (bsgalone_server PUBLIC
 	bsgalone-interface-library
-	core_utils
+	core_lib
 	net_lib
 	bsgo_lib
 	server_lib

--- a/src/server/lib/CMakeLists.txt
+++ b/src/server/lib/CMakeLists.txt
@@ -24,7 +24,7 @@ target_sources (server_lib PRIVATE
 	)
 
 target_link_libraries (server_lib
-	core_utils
+	core_lib
 	net_lib
 	bsgo_lib
 	)

--- a/src/server/lib/Server.cc
+++ b/src/server/lib/Server.cc
@@ -4,12 +4,12 @@
 #include "DataSource.hh"
 #include "LogoutMessage.hh"
 #include "SystemProcessorUtils.hh"
-#include <core_utils/TimeUtils.hh>
+#include "TimeUtils.hh"
 
 namespace bsgo {
 
 Server::Server()
-  : utils::CoreObject("server")
+  : core::CoreObject("server")
 {
   setService("server");
   initialize();

--- a/src/server/lib/Server.hh
+++ b/src/server/lib/Server.hh
@@ -5,16 +5,16 @@
 #include "BroadcastMessageQueue.hh"
 #include "ClientManager.hh"
 #include "Context.hh"
+#include "CoreObject.hh"
 #include "MessageExchanger.hh"
 #include "NetworkSystem.hh"
 #include "SystemProcessor.hh"
 #include "TcpServer.hh"
 #include <atomic>
 #include <condition_variable>
-#include <core_utils/CoreObject.hh>
 
 namespace bsgo {
-class Server : public utils::CoreObject
+class Server : public core::CoreObject
 {
   public:
   Server();

--- a/src/server/lib/clients/ClientManager.cc
+++ b/src/server/lib/clients/ClientManager.cc
@@ -5,7 +5,7 @@ namespace bsgo {
 Uuid ClientManager::NEXT_CLIENT_ID{0};
 
 ClientManager::ClientManager()
-  : utils::CoreObject("manager")
+  : core::CoreObject("manager")
 {
   setService("client");
 }

--- a/src/server/lib/clients/ClientManager.hh
+++ b/src/server/lib/clients/ClientManager.hh
@@ -2,8 +2,8 @@
 #pragma once
 
 #include "Connection.hh"
+#include "CoreObject.hh"
 #include "Uuid.hh"
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -11,7 +11,7 @@
 
 namespace bsgo {
 
-class ClientManager : public utils::CoreObject
+class ClientManager : public core::CoreObject
 {
   public:
   ClientManager();

--- a/src/server/lib/game/SystemProcessor.cc
+++ b/src/server/lib/game/SystemProcessor.cc
@@ -7,7 +7,7 @@
 namespace bsgo {
 
 SystemProcessor::SystemProcessor(const Uuid systemDbId)
-  : utils::CoreObject("processor")
+  : core::CoreObject("processor")
   , m_systemDbId(systemDbId)
   , m_inputMessagesQueue(std::make_unique<SynchronizedMessageQueue>(
       "synchronized-message-queue-for-" + std::to_string(m_systemDbId)))
@@ -77,16 +77,16 @@ void SystemProcessor::stop()
 void SystemProcessor::asyncSystemProcessing()
 {
   bool running{true};
-  auto lastFrameTimestamp = utils::now();
+  auto lastFrameTimestamp = core::now();
 
   debug("Started processing for system");
   while (running)
   {
-    constexpr auto SLEEP_DURATION_WHEN_PROCESSING = utils::Milliseconds(50);
+    constexpr auto SLEEP_DURATION_WHEN_PROCESSING = core::Milliseconds(50);
     std::this_thread::sleep_for(SLEEP_DURATION_WHEN_PROCESSING);
 
-    const auto thisFrameTimestamp = utils::now();
-    const auto elapsedMs          = utils::diffInMs(lastFrameTimestamp, thisFrameTimestamp);
+    const auto thisFrameTimestamp = core::now();
+    const auto elapsedMs          = core::diffInMs(lastFrameTimestamp, thisFrameTimestamp);
 
     constexpr auto MS_IN_A_SECOND = 1'000;
     m_coordinator->update(elapsedMs / MS_IN_A_SECOND);

--- a/src/server/lib/game/SystemProcessor.hh
+++ b/src/server/lib/game/SystemProcessor.hh
@@ -2,20 +2,20 @@
 #pragma once
 
 #include "Coordinator.hh"
+#include "CoreObject.hh"
 #include "DatabaseEntityMapper.hh"
 #include "IMessageQueue.hh"
 #include "Services.hh"
 #include "SynchronizedMessageQueue.hh"
 #include "Uuid.hh"
 #include <atomic>
-#include <core_utils/CoreObject.hh>
 #include <memory>
 #include <thread>
 #include <unordered_map>
 
 namespace bsgo {
 
-class SystemProcessor : public utils::CoreObject
+class SystemProcessor : public core::CoreObject
 {
   public:
   SystemProcessor(const Uuid systemDbId);

--- a/src/server/lib/queues/BroadcastMessageQueue.cc
+++ b/src/server/lib/queues/BroadcastMessageQueue.cc
@@ -13,7 +13,7 @@
 namespace bsgo {
 
 BroadcastMessageQueue::BroadcastMessageQueue(ClientManagerShPtr clientManager)
-  : utils::CoreObject("broadcast-message-queue")
+  : core::CoreObject("broadcast-message-queue")
   , m_clientManager(std::move(clientManager))
 {
   setService("message");

--- a/src/server/lib/queues/BroadcastMessageQueue.hh
+++ b/src/server/lib/queues/BroadcastMessageQueue.hh
@@ -2,9 +2,9 @@
 #pragma once
 
 #include "ClientManager.hh"
+#include "CoreObject.hh"
 #include "IMessageQueue.hh"
 #include "Uuid.hh"
-#include <core_utils/CoreObject.hh>
 #include <deque>
 #include <memory>
 #include <mutex>
@@ -13,7 +13,7 @@
 
 namespace bsgo {
 
-class BroadcastMessageQueue : public IMessageQueue, public utils::CoreObject
+class BroadcastMessageQueue : public IMessageQueue, public core::CoreObject
 {
   public:
   BroadcastMessageQueue(ClientManagerShPtr clientManager);

--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -1,12 +1,11 @@
 
 /// @brief - A minimalistic bsg server implementation
 
+#include "CoreException.hh"
 #include "Server.hh"
-#include <core_utils/CoreException.hh>
-#include <core_utils/log/Locator.hh>
-#include <core_utils/log/PrefixedLogger.hh>
-#include <core_utils/log/StdLogger.hh>
-#include <functional>
+#include "log/Locator.hh"
+#include "log/PrefixedLogger.hh"
+#include "log/StdLogger.hh"
 
 namespace {
 // https://stackoverflow.com/questions/11468414/using-auto-and-lambda-to-handle-signal
@@ -59,10 +58,10 @@ auto getPortFromEnvironmentVariable() -> int
 int main(int /*argc*/, char ** /*argv*/)
 {
   // Create the logger.
-  utils::log::StdLogger raw;
-  raw.setLevel(utils::log::Severity::DEBUG);
-  utils::log::PrefixedLogger logger("server", "main");
-  utils::log::Locator::provide(&raw);
+  core::log::StdLogger raw;
+  raw.setLevel(core::log::Severity::DEBUG);
+  core::log::PrefixedLogger logger("server", "main");
+  core::log::Locator::provide(&raw);
 
   try
   {
@@ -73,7 +72,7 @@ int main(int /*argc*/, char ** /*argv*/)
 
     server.run(getPortFromEnvironmentVariable());
   }
-  catch (const utils::CoreException &e)
+  catch (const core::CoreException &e)
   {
     logger.error("Caught internal exception while setting up application", e.what());
     return EXIT_FAILURE;

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -12,5 +12,5 @@ target_include_directories (integrationTests PUBLIC
 target_link_libraries (integrationTests
 	GTest::gtest_main
 	bsgalone-interface-test-library
-	core_utils
+	core_lib
 	)

--- a/tests/integration/main.cc
+++ b/tests/integration/main.cc
@@ -1,17 +1,17 @@
 
-#include <core_utils/CoreException.hh>
-#include <core_utils/log/Locator.hh>
-#include <core_utils/log/PrefixedLogger.hh>
-#include <core_utils/log/StdLogger.hh>
+#include "CoreException.hh"
+#include "log/Locator.hh"
+#include "log/PrefixedLogger.hh"
+#include "log/StdLogger.hh"
 
 #include <gtest/gtest.h>
 
 int main(int argc, char **argv)
 {
-  utils::log::StdLogger raw;
-  raw.setLevel(utils::log::Severity::DEBUG);
-  utils::log::PrefixedLogger logger("integration", "main");
-  utils::log::Locator::provide(&raw);
+  core::log::StdLogger raw;
+  raw.setLevel(core::log::Severity::DEBUG);
+  core::log::PrefixedLogger logger("integration", "main");
+  core::log::Locator::provide(&raw);
 
   testing::InitGoogleTest(&argc, argv);
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -20,7 +20,6 @@ target_include_directories (unitTests PUBLIC
 target_link_libraries (unitTests
 	GTest::gtest_main
 	bsgalone-interface-test-library
-	core_utils
 	core_lib
 	bsgo_lib
 	pge_lib

--- a/tests/unit/bsgo/messages/Common.hxx
+++ b/tests/unit/bsgo/messages/Common.hxx
@@ -3,7 +3,7 @@
 
 #include "Common.hh"
 #include "IMessage.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 #include <sstream>
 
 namespace bsgo {
@@ -12,10 +12,10 @@ template<typename T>
 inline auto serializeAndDeserialize(const T &value, T &output)
 {
   std::ostringstream out{};
-  utils::serialize(out, value);
+  core::serialize(out, value);
   std::istringstream in(out.str());
 
-  utils::deserialize(in, output);
+  core::deserialize(in, output);
 }
 
 inline auto serializeAndDeserializeMessage(const IMessage &value, IMessage &output)

--- a/tests/unit/bsgo/messages/MessageTypeTest.cc
+++ b/tests/unit/bsgo/messages/MessageTypeTest.cc
@@ -1,6 +1,6 @@
 
 #include "MessageType.hh"
-#include <core_utils/SerializationUtils.hh>
+#include "SerializationUtils.hh"
 #include <gtest/gtest.h>
 #include <sstream>
 
@@ -20,11 +20,11 @@ TEST_P(TestCaseSerialization, Serialization)
   const auto &param = GetParam();
 
   std::ostringstream out;
-  utils::serialize(out, param.type);
+  core::serialize(out, param.type);
   std::istringstream in(out.str());
 
   MessageType expected;
-  utils::deserialize(in, expected);
+  core::deserialize(in, expected);
 
   EXPECT_EQ(param.type, expected);
 }

--- a/tests/unit/bsgo/messages/OptionalTest.cc
+++ b/tests/unit/bsgo/messages/OptionalTest.cc
@@ -31,14 +31,14 @@ TEST(Unit_Bsgo_Serialization_Optional_Uuid, EmptyAndSomeValueAfter)
   const auto expectedFloat{1.68f};
 
   std::ostringstream out;
-  utils::serialize(out, expectedOpt);
-  utils::serialize(out, expectedFloat);
+  core::serialize(out, expectedOpt);
+  core::serialize(out, expectedFloat);
   std::istringstream in(out.str());
 
   std::optional<Uuid> actualOpt{};
   float actualFloat{};
-  utils::deserialize(in, actualOpt);
-  utils::deserialize(in, actualFloat);
+  core::deserialize(in, actualOpt);
+  core::deserialize(in, actualFloat);
 
   EXPECT_EQ(actualOpt, expectedOpt);
   EXPECT_EQ(actualFloat, expectedFloat);
@@ -50,14 +50,14 @@ TEST(Unit_Bsgo_Serialization_Optional_Uuid, WithValueAndSomeValueAfter)
   const auto expectedSlot{Slot::COMPUTER};
 
   std::ostringstream out;
-  utils::serialize(out, expectedOpt);
-  utils::serialize(out, expectedSlot);
+  core::serialize(out, expectedOpt);
+  core::serialize(out, expectedSlot);
   std::istringstream in(out.str());
 
   std::optional<Uuid> actualOpt{};
   Slot actualSlot{};
-  utils::deserialize(in, actualOpt);
-  utils::deserialize(in, actualSlot);
+  core::deserialize(in, actualOpt);
+  core::deserialize(in, actualSlot);
 
   EXPECT_EQ(actualOpt, expectedOpt);
   EXPECT_EQ(actualSlot, expectedSlot);

--- a/tests/unit/bsgo/messages/SerializationBehaviorTest.cc
+++ b/tests/unit/bsgo/messages/SerializationBehaviorTest.cc
@@ -1,6 +1,6 @@
 
+#include "SerializationUtils.hh"
 #include "Uuid.hh"
-#include <core_utils/SerializationUtils.hh>
 #include <gtest/gtest.h>
 #include <sstream>
 
@@ -20,7 +20,7 @@ template<typename T>
 bool serializeAndDeserialize(const T &expected, const bool truncate)
 {
   std::ostringstream out{};
-  utils::serialize(out, expected);
+  core::serialize(out, expected);
 
   auto serialized = out.str();
   if (truncate)
@@ -30,7 +30,7 @@ bool serializeAndDeserialize(const T &expected, const bool truncate)
   std::istringstream in(serialized);
 
   T output{};
-  return utils::deserialize(in, output);
+  return core::deserialize(in, output);
 }
 
 template<>

--- a/tests/unit/bsgo/messages/SlotComponentMessageTest.cc
+++ b/tests/unit/bsgo/messages/SlotComponentMessageTest.cc
@@ -22,7 +22,7 @@ auto assertMessagesAreEqual(const SlotComponentMessage &actual, const SlotCompon
 TEST(Unit_Bsgo_Serialization_SlotComponentMessage, Empty)
 {
   const SlotComponentMessage expected(Uuid{999}, Uuid{14}, Uuid{2}, {});
-  SlotComponentMessage actual(Uuid{10}, Uuid{36}, Uuid{1}, utils::Milliseconds(300));
+  SlotComponentMessage actual(Uuid{10}, Uuid{36}, Uuid{1}, core::Milliseconds(300));
   actual.setClientId(Uuid{44});
   serializeAndDeserializeMessage(expected, actual);
   assertMessagesAreEqual(actual, expected);
@@ -30,7 +30,7 @@ TEST(Unit_Bsgo_Serialization_SlotComponentMessage, Empty)
 
 TEST(Unit_Bsgo_Serialization_SlotComponentMessage, WithElapsedSinceLastFired)
 {
-  const SlotComponentMessage expected(Uuid{999}, Uuid{14}, Uuid{2}, utils::Milliseconds(250));
+  const SlotComponentMessage expected(Uuid{999}, Uuid{14}, Uuid{2}, core::Milliseconds(250));
   SlotComponentMessage actual(Uuid{10}, Uuid{36}, Uuid{1}, {});
   actual.setClientId(Uuid{44});
   serializeAndDeserializeMessage(expected, actual);
@@ -39,7 +39,7 @@ TEST(Unit_Bsgo_Serialization_SlotComponentMessage, WithElapsedSinceLastFired)
 
 TEST(Unit_Bsgo_Serialization_SlotComponentMessage, WithClientId)
 {
-  SlotComponentMessage expected(Uuid{999}, Uuid{28}, Uuid{67}, utils::Milliseconds(250));
+  SlotComponentMessage expected(Uuid{999}, Uuid{28}, Uuid{67}, core::Milliseconds(250));
   expected.setClientId(Uuid{119});
   SlotComponentMessage actual(Uuid{10}, Uuid{51}, Uuid{180}, {});
   serializeAndDeserializeMessage(expected, actual);
@@ -48,7 +48,7 @@ TEST(Unit_Bsgo_Serialization_SlotComponentMessage, WithClientId)
 
 TEST(Unit_Bsgo_Serialization_SlotComponentMessage, Clone)
 {
-  const SlotComponentMessage expected(Uuid{999}, Uuid{28}, Uuid{67}, utils::Milliseconds(250));
+  const SlotComponentMessage expected(Uuid{999}, Uuid{28}, Uuid{67}, core::Milliseconds(250));
   const auto cloned = expected.clone();
   ASSERT_EQ(cloned->type(), MessageType::SLOT_COMPONENT_UPDATED);
   assertMessagesAreEqual(cloned->as<SlotComponentMessage>(), expected);

--- a/tests/unit/bsgo/messages/UuidTest.cc
+++ b/tests/unit/bsgo/messages/UuidTest.cc
@@ -21,14 +21,14 @@ TEST(Unit_Bsgo_Serialization_Uuid, MultipleValues)
   Uuid expected2{36};
 
   std::ostringstream out;
-  utils::serialize(out, expected1);
-  utils::serialize(out, expected2);
+  core::serialize(out, expected1);
+  core::serialize(out, expected2);
   std::istringstream in(out.str());
 
   Uuid actual1{3};
   Uuid actual2{27};
-  utils::deserialize(in, actual1);
-  utils::deserialize(in, actual2);
+  core::deserialize(in, actual1);
+  core::deserialize(in, actual2);
 
   EXPECT_EQ(actual1, expected1);
   EXPECT_EQ(actual2, expected2);

--- a/tests/unit/main.cc
+++ b/tests/unit/main.cc
@@ -1,17 +1,17 @@
 
-#include <core_utils/CoreException.hh>
-#include <core_utils/log/Locator.hh>
-#include <core_utils/log/PrefixedLogger.hh>
-#include <core_utils/log/StdLogger.hh>
+#include "CoreException.hh"
+#include "log/Locator.hh"
+#include "log/PrefixedLogger.hh"
+#include "log/StdLogger.hh"
 
 #include <gtest/gtest.h>
 
 int main(int argc, char **argv)
 {
-  utils::log::StdLogger raw;
-  raw.setLevel(utils::log::Severity::DEBUG);
-  utils::log::PrefixedLogger logger("unit", "main");
-  utils::log::Locator::provide(&raw);
+  core::log::StdLogger raw;
+  raw.setLevel(core::log::Severity::DEBUG);
+  core::log::PrefixedLogger logger("unit", "main");
+  core::log::Locator::provide(&raw);
 
   testing::InitGoogleTest(&argc, argv);
 


### PR DESCRIPTION
# Work

Currently the project is using the [core_utils](https://github.com/Knoblauchpilze/core_utils) library. This project is a separate dependency providing common utilities such as logging, time manipulation primitives and more.

In order to make this project more self-contained, it is interesting to bring back the features into this repository. This would be similar to what was done in the [tcp-server](https://github.com/Knoblauchpilze/tcp-server/tree/master/src/core) project.

This will also help when introducing the CI for this project as we won't have to clone multiple repositories and only use the content of this one.

The main changes are:
* replaced link to `core_utils` by `core_lib`
* replaced includes of `<core_utils/file.hh>` by `"file.hh"`
* replaced occurrences of `utils::ClassName` with `core::ClassName`
* included [SerializationUtils](https://github.com/Knoblauchpilze/core_utils/blob/master/src/SerializationUtils.hh) file as it's used in the messages

# Tests

Verified locally that:
* compiling the project from scratch works
* running both client and server works and allows to play the game
* running both sets of tests works

# Future work

We still need to work on introducing the CI workflow. It would be similar to the work available in the [tcp-server](https://github.com/Knoblauchpilze/tcp-server) repo.
