### PR TITLE
feat: Added Dockerfile and github workflow to build the CI image

### DIFF
--- a/.github/workflows/build-ci-docker-image.yml
+++ b/.github/workflows/build-ci-docker-image.yml
@@ -1,4 +1,4 @@
-name: Build services
+name: Build CI docker image
 
 on:
   push:

--- a/.github/workflows/build-ci-docker-image.yml
+++ b/.github/workflows/build-ci-docker-image.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "version=${{ github.event.inputs.cpp_version || env.CPP_VERSION }}" >> $GITHUB_OUTPUT
       - name: Determine libpqxx version
-        id: libpxx-version
+        id: libpqxx-version
         run: |
           echo "version=${{ github.event.inputs.libpqxx_version || env.LIBPQXX_VERSION }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-ci-docker-image.yml
+++ b/.github/workflows/build-ci-docker-image.yml
@@ -1,0 +1,54 @@
+name: Build services
+
+on:
+  push:
+    paths:
+      - ".github/workflows/build-ci-docker-image.yml"
+      - "build/ci/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  LIBPQXX_VERSION: 7.10.1
+  CPP_VERSION: 20
+
+jobs:
+  extract-docker-tag:
+    runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
+    outputs:
+      tag: ${{ steps.docker-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract git commit hash
+        id: docker-tag
+        # https://stackoverflow.com/questions/58886293/getting-current-branch-and-commit-hash-in-github-action
+        run: echo "tag=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_OUTPUT
+
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      build-and-push-docker-image:
+    runs-on: ubuntu-latest
+    needs: [extract-docker-tag]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./build/ci-cpp-build-image/Dockerfile
+          # https://github.com/docker/build-push-action/issues/380
+          build-args: |
+            CPP_VERSION=$CPP_VERSION
+            LIBPQXX_VERSION=$LIBPQXX_VERSION
+          push: true
+          tags: totocorpsoftwareinc/ci-cpp-build-image:${{ needs.extract-docker-tag.outputs.tag }}

--- a/.github/workflows/build-ci-docker-image.yml
+++ b/.github/workflows/build-ci-docker-image.yml
@@ -46,9 +46,9 @@ jobs:
         # https://stackoverflow.com/questions/58886293/getting-current-branch-and-commit-hash-in-github-action
         run: |
           GIT_COMMIT_SHA=$(git rev-parse --short $GITHUB_SHA)
-          TAG=${{ github.event.inputs.tag }}
-          if [ $TAG == "" ]; then
-            TAG=$GIT_COMMIT_SHA
+          TAG="${{ github.event.inputs.tag }}"
+          if [ "$TAG" == "" ]; then
+            TAG="$GIT_COMMIT_SHA"
           fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Determine C++ version

--- a/.github/workflows/build-ci-docker-image.yml
+++ b/.github/workflows/build-ci-docker-image.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - ".github/workflows/build-ci-docker-image.yml"
-      - "build/ci/**"
+      - "build/ci-cpp-build-image/**"
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/build-ci-docker-image.yml
+++ b/.github/workflows/build-ci-docker-image.yml
@@ -46,7 +46,7 @@ jobs:
         # https://stackoverflow.com/questions/58886293/getting-current-branch-and-commit-hash-in-github-action
         run: |
           GIT_COMMIT_SHA=$(git rev-parse --short $GITHUB_SHA)
-          TAG=${{ github.event.inputs.tag }}"
+          TAG=${{ github.event.inputs.tag }}
           if [ $TAG == "" ]; then
             TAG=$GIT_COMMIT_SHA
           fi

--- a/.github/workflows/build-ci-docker-image.yml
+++ b/.github/workflows/build-ci-docker-image.yml
@@ -5,34 +5,64 @@ on:
     paths:
       - ".github/workflows/build-ci-docker-image.yml"
       - "build/ci/**"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker tag to use for the image"
+        required: false
+        default: ""
+      cpp_version:
+        description: "C++ version to use"
+        required: false
+        default: "20"
+      libpqxx_version:
+        description: "Version of libpqxx to use"
+        required: false
+        default: "7.10.1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
-  LIBPQXX_VERSION: 7.10.1
   CPP_VERSION: 20
+  LIBPQXX_VERSION: 7.10.1
 
 jobs:
-  extract-docker-tag:
+  docker-props:
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:
       tag: ${{ steps.docker-tag.outputs.tag }}
+      cpp-version: ${{ steps.cpp-version.outputs.version }}
+      libpqxx-version: ${{ steps.libpqxx-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
-      - name: Extract git commit hash
+      - name: debug
+        run: |
+          echo ${{ github.event_name }}
+      - name: Extract docker tag
         id: docker-tag
         # https://stackoverflow.com/questions/58886293/getting-current-branch-and-commit-hash-in-github-action
-        run: echo "tag=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_OUTPUT
+        run: |
+          GIT_COMMIT_SHA=$(git rev-parse --short $GITHUB_SHA)
+          TAG=${{ github.event.inputs.tag }}"
+          if [ $TAG == "" ]; then
+            TAG=$GIT_COMMIT_SHA
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+      - name: Determine C++ version
+        id: cpp-version
+        run: |
+          echo "version=${{ github.event.inputs.cpp_version || env.CPP_VERSION }}" >> $GITHUB_OUTPUT
+      - name: Determine libpqxx version
+        id: libpxx-version
+        run: |
+          echo "version=${{ github.event.inputs.libpqxx_version || env.LIBPQXX_VERSION }}" >> $GITHUB_OUTPUT
 
-  build:
-    runs-on: ubuntu-24.04
-    steps:
-      build-and-push-docker-image:
+  build-and-push-docker-image:
     runs-on: ubuntu-latest
-    needs: [extract-docker-tag]
+    needs: [docker-props]
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
@@ -48,7 +78,7 @@ jobs:
           file: ./build/ci-cpp-build-image/Dockerfile
           # https://github.com/docker/build-push-action/issues/380
           build-args: |
-            CPP_VERSION=$CPP_VERSION
-            LIBPQXX_VERSION=$LIBPQXX_VERSION
+            CPP_VERSION=${{ needs.docker-props.outputs.cpp-version }}
+            LIBPQXX_VERSION=${{ needs.docker-props.outputs.libpqxx-version }}
           push: true
-          tags: totocorpsoftwareinc/ci-cpp-build-image:${{ needs.extract-docker-tag.outputs.tag }}
+          tags: totocorpsoftwareinc/ci-cpp-build-image:${{ needs.docker-props.outputs.tag }}

--- a/Makefile
+++ b/Makefile
@@ -73,5 +73,5 @@ runintegrationtests: tests
 ci-cpp-build-image:
 	docker build \
 		--tag totocorpsoftwareinc/ci-cpp-build-image:${DOCKER_IMAGE_TAG} \
-		-f build/ci/Dockerfile \
-		build/ci
+		-f build/ci-cpp-build-image/Dockerfile \
+		build/ci-cpp-build-image

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 
-GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD)
+# Keep in sync with the CI workflow
+LIBPQXX_VERSION=7.10.1
+CPP_VERSION=20
+DOCKER_IMAGE_TAG="${CPP_VERSION}-${LIBPQXX_VERSION}"
 
 debug:
 	mkdir -p cmake-build/Debug && \
@@ -66,3 +69,9 @@ rununittests: tests
 
 runintegrationtests: tests
 	cd sandbox && ./tests.sh integrationTests
+
+ci-cpp-build-image:
+	docker build \
+		--tag totocorpsoftwareinc/ci-cpp-build-image:${DOCKER_IMAGE_TAG} \
+		-f build/ci/Dockerfile \
+		build/ci

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Some known limitations:
 - various edge cases where the server will crash
 - client applications access the DB directly with the same user as the server
 
+# Badges
+
+[![Build CI docker image](https://github.com/Knoblauchpilze/bsgalone/actions/workflows/build-ci-docker-image.yml/badge.svg)](https://github.com/Knoblauchpilze/bsgalone/actions/workflows/build-ci-docker-image.yml)
+
 # Installation
 
 ⚠️ The following sections are tailored for an installation on Ubuntu: this is what was used during the development. If you want to try to install it on another OS it probably works but some of the command will need to be adapted.

--- a/build/ci-cpp-build-image/Dockerfile
+++ b/build/ci-cpp-build-image/Dockerfile
@@ -1,0 +1,45 @@
+
+FROM ubuntu:24.04 AS dev-tools
+# https://docs.docker.com/build/building/best-practices/#apt-get
+# https://docs.datadoghq.com/security/code_security/static_analysis/static_analysis_rules/docker-best-practices/apt-pin-version/
+# https://stackoverflow.com/questions/34773745/debconf-unable-to-initialize-frontend-dialog
+# https://stackoverflow.com/questions/37970990/ssl-certificate-verification-fails-inside-docker-container-on-specific-server
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+  ca-certificates=20240203 \
+  build-essential=12.10ubuntu1 \
+  wget=1.21.4-1ubuntu4.1 \
+  cmake=3.28.3-1build7 \
+  pkg-config=1.8.1-2build1 \
+  libpq-dev=16.9-0ubuntu0.24.04.1 \
+  libx11-dev=2:1.8.7-1build1 \
+  libgl-dev=1.7.0-1build1 \
+  libasio-dev=1:1.28.1-0.2 \
+  libeigen3-dev=3.4.0-4build0.1 \
+  libpng-dev=1.6.43-5build1 \
+  libgtest-dev=1.14.0-1 \
+  rsync=3.2.7-1ubuntu1.2 \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG CPP_VERSION="20"
+ARG LIBPQXX_VERSION="7.10.1"
+ENV CPP_VERSION=$CPP_VERSION
+ENV LIBPQXX_VERSION=$LIBPQXX_VERSION
+FROM dev-tools AS ci-build-base
+WORKDIR /tmp
+RUN wget https://github.com/jtv/libpqxx/archive/refs/tags/${LIBPQXX_VERSION}.tar.gz -O libpqxx.tar.gz
+RUN tar -xzf libpqxx.tar.gz
+WORKDIR libpqxx-${LIBPQXX_VERSION}
+RUN cmake \
+      -DCMAKE_CXX_STANDARD=${CPP_VERSION} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=1 \
+      .
+RUN cmake --build . -j 8
+RUN cmake --install .
+
+FROM dev-tools AS ci-cpp-build-image
+ARG GIT_COMMIT_HASH="undefined"
+ENV GIT_COMMIT_HASH=$GIT_COMMIT_HASH
+WORKDIR /
+COPY --from=ci-build-base /usr/local/lib /usr/local/lib/
+COPY --from=ci-build-base /usr/local/include/pqxx /usr/local/include/pqxx

--- a/build/ci-cpp-build-image/Dockerfile
+++ b/build/ci-cpp-build-image/Dockerfile
@@ -1,10 +1,11 @@
 
 FROM ubuntu:24.04 AS dev-tools
+# https://stackoverflow.com/questions/34773745/debconf-unable-to-initialize-frontend-dialog
+ENV DEBIAN_FRONTEND="noninteractive"
 # https://docs.docker.com/build/building/best-practices/#apt-get
 # https://docs.datadoghq.com/security/code_security/static_analysis/static_analysis_rules/docker-best-practices/apt-pin-version/
-# https://stackoverflow.com/questions/34773745/debconf-unable-to-initialize-frontend-dialog
 # https://stackoverflow.com/questions/37970990/ssl-certificate-verification-fails-inside-docker-container-on-specific-server
-RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates=20240203 \
   build-essential=12.10ubuntu1 \
   wget=1.21.4-1ubuntu4.1 \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,14 +1,5 @@
 
-# http://google.github.io/googletest/quickstart-cmake.html
-# https://cmake.org/cmake/help/latest/module/FetchContent.html
-include (FetchContent)
-FetchContent_Declare (
-	googletest
-	GIT_REPOSITORY https://github.com/google/googletest.git
-	GIT_TAG        v1.15.2
-)
-
-FetchContent_MakeAvailable (googletest)
+find_package(GTest REQUIRED)
 
 add_subdirectory (
 	${CMAKE_CURRENT_SOURCE_DIR}/unit


### PR DESCRIPTION
# Work

## Context

Building this project in the CI requires to install a couple of libraries (see #5 for more details). It also requires to persist those installation steps between different CI steps (typically the build and the tests). In order to to this, one solution is to create a dedicated Docker image for it and use it in the CI workflow so that all tools are readily available.

## Implementation details

The docker build image workflow is very similar to the logic we use in other services. The goal is to:
* install common tools (compiler, `cmake`, etc.)
* install needed libraries to compile the project (`libpqxx`, `asio`, etc.)

It is crucial to keep the libraries installed in the docker image in sync with the requirements of the project.

The workflow also allows to easily customize the version of the C++ language used to compile the `libpqxx` and its version. This allows to make sure that the compiled version will be compatible with the code of the project.

When an image is successfully built, it will be pushed and uploaded to [dockerhub](https://hub.docker.com/r/docker/totocorpsoftwareinc/ci-cpp-build-image).

## How to use the workflow?

This workflow can be used in two ways:
* triggered automatically on pushing changes to the workflow file
* through a workflow dispatch

The idea of the second way to use it is to easily allow bumping the version of one or other library. This allows to trigger a build without having to change the file and for example see how it would work with a more recent version of `libpqxx`.

We expect that it's not so frequent to have to regenerate a CI build image.

# Tests

Locally we can start the build of the service in the docker image. We also double checked that it is possible to specify a docker container in which the command will be run in a GitHub workflow (see [source](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container#example-running-a-job-within-a-container)): this will enable to adapt the workflow added in #5 to use the image produced by this step.

# Future work

We can use the work brought in this PR in #5 and build the project in the CI.
