### PR TITLE
chore: Installed lcov in CI base image

### DIFF
--- a/build/ci-cpp-build-image/Dockerfile
+++ b/build/ci-cpp-build-image/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libpng-dev=1.6.43-5build1 \
   libgtest-dev=1.14.0-1 \
   rsync=3.2.7-1ubuntu1.2 \
+  lcov=2.0-4ubuntu2 \
   && rm -rf /var/lib/apt/lists/*
 
 ARG CPP_VERSION="20"


### PR DESCRIPTION
# Work

After using the CI base image in #5 (see [1e6c49e](https://github.com/Knoblauchpilze/bsgalone/pull/5/commits/1e6c49eb4324bf082ba8d10d290f4a093a3477cf) and [33ae62d](https://github.com/Knoblauchpilze/bsgalone/pull/5/commits/33ae62ddf28970028383babe5986e599ddd356ca), we noticed that we still need to install `lcov` in both unit and integration tests. This could be tackled as part of the base image building.

In this PR, we do just that.

# Tests

When using this image in #5 (see [2405a90](https://github.com/Knoblauchpilze/bsgalone/pull/5/commits/2405a909b3ad29c965272e32fc86cc1b5f48b8cb)) allows to get passed the installation.

# Future work

N/A
