### PR TITLE
fix: Test coverage upload is broken

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -117,6 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit-tests, integration-tests]
     steps:
+      - uses: actions/checkout@v4
       - name: Download unit test coverage data
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -62,6 +62,26 @@ jobs:
       - name: Run tests
         run: |
           ./sandbox/bin/unitTests
+      - name: Compress project folder
+        run: |
+          tar -cvf unit-tests-data.tar .
+      - name: Upload unit tests result
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-tests-data
+          path: unit-tests-data.tar
+
+  upload-unit-tests-coverage:
+    runs-on: ubuntu-latest
+    needs: [unit-tests]
+    steps:
+      - name: Download unit tests data
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-tests-data
+      - name: Uncompress unit tests data
+        run: |
+          tar -xvf unit-tests-data.tar
       - name: Aggregate code coverage
         # https://github.com/linux-test-project/lcov/issues/296
         # https://stackoverflow.com/questions/38438219/how-to-remove-certain-directories-from-lcov-code-coverage-report
@@ -71,15 +91,18 @@ jobs:
             --exclude=\/usr\/include\/* \
             --exclude=*tests\/* \
             --capture \
-            --output-file coverage-unit.info
+            --output-file coverage.info
       - name: Display coverage
         run: |
-          lcov --list coverage-unit.info
-      - name: Upload coverage info
-        uses: actions/upload-artifact@v4
+          lcov --list coverage.info
+      - name: Upload coverage to Codecov
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: codecov/codecov-action@v5
         with:
-          name: coverage-unit
-          path: coverage-unit.info
+          fail_ci_if_error: true
+          handle_no_reports_found: true
+          files: ./coverage.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -96,6 +119,23 @@ jobs:
       - name: Run tests
         run: |
           ./sandbox/bin/integrationTests
+      - name: Upload integration tests result
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-tests-data
+          path: integration-tests-data.tar
+
+  upload-integration-tests-coverage:
+    runs-on: ubuntu-latest
+    needs: [integration-tests]
+    steps:
+      - name: Download integration tests data
+        uses: actions/download-artifact@v4
+        with:
+          name: integration-tests-data
+      - name: Uncompress integration tests data
+        run: |
+          tar -xvf integration-tests-data.tar
       - name: Aggregate code coverage
         run: |
           lcov \
@@ -103,34 +143,15 @@ jobs:
             --exclude=\/usr\/include\/* \
             --exclude=*tests\/* \
             --capture \
-            --output-file coverage-integration.info
+            --output-file coverage.info
       - name: Display coverage
         run: |
-          lcov --list coverage-integration.info
-      - name: Upload coverage info
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-integration
-          path: coverage-integration.info
-
-  upload-coverage:
-    runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download unit test coverage data
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-unit
-      - name: Download integration test coverage data
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-integration
+          lcov --list coverage.info
       - name: Upload coverage to Codecov
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           handle_no_reports_found: true
-          files: ./coverage-unit.info,./coverage-integration.info
+          files: ./coverage.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Uncompress unit tests data
         run: |
           tar -xvf unit-tests-data.tar
+      - name: Install lcov
+        run: |
+          sudo apt-get install -y lcov=2.0-4ubuntu2
       - name: Aggregate code coverage
         # https://github.com/linux-test-project/lcov/issues/296
         # https://stackoverflow.com/questions/38438219/how-to-remove-certain-directories-from-lcov-code-coverage-report
@@ -119,6 +122,9 @@ jobs:
       - name: Run tests
         run: |
           ./sandbox/bin/integrationTests
+      - name: Compress project folder
+        run: |
+          tar -cvf integration-tests-data.tar .
       - name: Upload integration tests result
         uses: actions/upload-artifact@v4
         with:
@@ -136,6 +142,9 @@ jobs:
       - name: Uncompress integration tests data
         run: |
           tar -xvf integration-tests-data.tar
+      - name: Install lcov
+        run: |
+          sudo apt-get install -y lcov=2.0-4ubuntu2
       - name: Aggregate code coverage
         run: |
           lcov \

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -62,29 +62,6 @@ jobs:
       - name: Run tests
         run: |
           ./sandbox/bin/unitTests
-      - name: Compress project folder
-        run: |
-          tar -cvf unit-tests-data.tar .
-      - name: Upload unit tests result
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-tests-data
-          path: unit-tests-data.tar
-
-  upload-unit-tests-coverage:
-    runs-on: ubuntu-latest
-    needs: [unit-tests]
-    steps:
-      - name: Download unit tests data
-        uses: actions/download-artifact@v4
-        with:
-          name: unit-tests-data
-      - name: Uncompress unit tests data
-        run: |
-          tar -xvf unit-tests-data.tar
-      - name: Install lcov
-        run: |
-          sudo apt-get install -y lcov=2.0-4ubuntu2
       - name: Aggregate code coverage
         # https://github.com/linux-test-project/lcov/issues/296
         # https://stackoverflow.com/questions/38438219/how-to-remove-certain-directories-from-lcov-code-coverage-report
@@ -94,18 +71,15 @@ jobs:
             --exclude=\/usr\/include\/* \
             --exclude=*tests\/* \
             --capture \
-            --output-file coverage.info
+            --output-file coverage-unit.info
       - name: Display coverage
         run: |
-          lcov --list coverage.info
-      - name: Upload coverage to Codecov
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: codecov/codecov-action@v5
+          lcov --list coverage-unit.info
+      - name: Upload coverage info
+        uses: actions/upload-artifact@v4
         with:
-          fail_ci_if_error: true
-          handle_no_reports_found: true
-          files: ./coverage.info
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-unit
+          path: coverage-unit.info
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -122,29 +96,6 @@ jobs:
       - name: Run tests
         run: |
           ./sandbox/bin/integrationTests
-      - name: Compress project folder
-        run: |
-          tar -cvf integration-tests-data.tar .
-      - name: Upload integration tests result
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-tests-data
-          path: integration-tests-data.tar
-
-  upload-integration-tests-coverage:
-    runs-on: ubuntu-latest
-    needs: [integration-tests]
-    steps:
-      - name: Download integration tests data
-        uses: actions/download-artifact@v4
-        with:
-          name: integration-tests-data
-      - name: Uncompress integration tests data
-        run: |
-          tar -xvf integration-tests-data.tar
-      - name: Install lcov
-        run: |
-          sudo apt-get install -y lcov=2.0-4ubuntu2
       - name: Aggregate code coverage
         run: |
           lcov \
@@ -152,15 +103,34 @@ jobs:
             --exclude=\/usr\/include\/* \
             --exclude=*tests\/* \
             --capture \
-            --output-file coverage.info
+            --output-file coverage-integration.info
       - name: Display coverage
         run: |
-          lcov --list coverage.info
+          lcov --list coverage-integration.info
+      - name: Upload coverage info
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-integration
+          path: coverage-integration.info
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    needs: [unit-tests, integration-tests]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download unit test coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-unit
+      - name: Download integration test coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-integration
       - name: Upload coverage to Codecov
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           handle_no_reports_found: true
-          files: ./coverage.info
+          files: ./coverage-unit.info,./coverage-integration.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,4 +4,4 @@ ignore:
   - "tests"
 # https://docs.codecov.com/docs/fixing-paths#how-to-provide-path-fixes-manually
 fixes:
-  - "/__w/bsgalone::"
+  - "/__w/::/home/runner/work/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,6 @@
 # https://docs.codecov.com/docs/ignoring-paths#ignoring-a-specific-folder
 ignore:
   - "tests"
+# https://docs.codecov.com/docs/fixing-paths#how-to-provide-path-fixes-manually
+fixes:
+  - "/__w/bsgalone::"


### PR DESCRIPTION
# Work

The implementation of the CI workflow brought in #5 is failing to produce meaningful test coverage data? This can be seen in the [codecov UI](https://app.codecov.io/gh/Knoblauchpilze/bsgalone/commit/3dcb88416d3d90863b22db5a8c622d00a40088fb):

![test-coverage-failure](https://github.com/user-attachments/assets/a25fe14e-3851-49a6-8d49-1201e60b296c)

## Research

Looking at the [troubleshooting guide](https://docs.codecov.com/docs/error-reference#unusable-reports) it can come from various reasons.

Comparing the differences between the working case (in `tcp-server`) and this project, the most likely problem is that running the tests in a docker container messes up with the way codecov is able to match/find the coverage data compared to the repository structure. This seems to be explained in a bit more details in this [path fixing section](https://docs.codecov.com/docs/fixing-paths#how-to-provide-path-fixes-manually).


# Tests

# Future work
