### PR TITLE
chore: Voluntarily break tests to check build caching

### DIFF
--- a/tests/unit/bsgo/messages/DockMessageTest.cc
+++ b/tests/unit/bsgo/messages/DockMessageTest.cc
@@ -9,7 +9,7 @@ namespace bsgo {
 namespace {
 auto assertMessagesAreEqual(const DockMessage &actual, const DockMessage &expected)
 {
-  EXPECT_EQ(actual.type(), expected.type());
+  EXPECT_NE(actual.type(), expected.type());
   EXPECT_EQ(actual.getShipDbId(), expected.getShipDbId());
   EXPECT_EQ(actual.isDocking(), expected.isDocking());
   EXPECT_EQ(actual.getSystemDbId(), expected.getSystemDbId());


### PR DESCRIPTION
# Work

In [e101f34](https://github.com/Knoblauchpilze/bsgalone/commit/e101f34b3c2ad9a0ce44aca2c0c44541c981273a) we fixed a bug introduced in [39028f3](https://github.com/Knoblauchpilze/bsgalone/commit/39028f37cf1957025104a3ab205951af9c865b87) but which did not break the CI (see [run](https://github.com/Knoblauchpilze/bsgalone/actions/runs/15434802974)):

![image](https://github.com/user-attachments/assets/e73fdae6-0ad9-4adb-a63b-d45dbf59a5cd)

It seems that the build result was a cache hit:

![image](https://github.com/user-attachments/assets/9d01694c-22b0-48e8-9e19-71d64288ce14)

And that nothing got rebuilt.

# Tests

# Future work
