### PR TITLE
feat: Added message to indicate start and end of loading process

### DIFF
--- a/src/bsgo/messages/CMakeLists.txt
+++ b/src/bsgo/messages/CMakeLists.txt
@@ -19,6 +19,8 @@ target_sources (bsgo_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpCancelledMessage.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpMessage.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpRequestedMessage.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/LoadingFinishedMessage.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/LoadingStartedMessage.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LoginMessage.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LogoutMessage.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LootMessage.cc

--- a/src/bsgo/messages/LoadingFinishedMessage.cc
+++ b/src/bsgo/messages/LoadingFinishedMessage.cc
@@ -1,0 +1,58 @@
+
+#include "LoadingFinishedMessage.hh"
+#include "SerializationUtils.hh"
+
+namespace bsgo {
+
+LoadingFinishedMessage::LoadingFinishedMessage()
+  : NetworkMessage(MessageType::LOADING_FINISHED)
+{}
+
+LoadingFinishedMessage::LoadingFinishedMessage(const Uuid systemDbId, const Uuid playerDbId)
+  : NetworkMessage(MessageType::LOADING_FINISHED)
+  , m_systemDbId(systemDbId)
+  , m_playerDbId(playerDbId)
+{}
+
+auto LoadingFinishedMessage::getSystemDbId() const -> Uuid
+{
+  return m_systemDbId;
+}
+
+auto LoadingFinishedMessage::getPlayerDbId() const -> Uuid
+{
+  return m_playerDbId;
+}
+
+auto LoadingFinishedMessage::serialize(std::ostream &out) const -> std::ostream &
+{
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+
+  core::serialize(out, m_systemDbId);
+  core::serialize(out, m_playerDbId);
+
+  return out;
+}
+
+bool LoadingFinishedMessage::deserialize(std::istream &in)
+{
+  bool ok{true};
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+
+  ok &= core::deserialize(in, m_systemDbId);
+  ok &= core::deserialize(in, m_playerDbId);
+
+  return ok;
+}
+
+auto LoadingFinishedMessage::clone() const -> IMessagePtr
+{
+  auto clone = std::make_unique<LoadingFinishedMessage>(m_systemDbId, m_playerDbId);
+  clone->copyClientIdIfDefined(*this);
+
+  return clone;
+}
+
+} // namespace bsgo

--- a/src/bsgo/messages/LoadingFinishedMessage.hh
+++ b/src/bsgo/messages/LoadingFinishedMessage.hh
@@ -1,0 +1,29 @@
+
+#pragma once
+
+#include "NetworkMessage.hh"
+#include "Uuid.hh"
+
+namespace bsgo {
+
+class LoadingFinishedMessage : public NetworkMessage
+{
+  public:
+  LoadingFinishedMessage();
+  LoadingFinishedMessage(const Uuid systemDbId, const Uuid playerDbId);
+  ~LoadingFinishedMessage() override = default;
+
+  auto getSystemDbId() const -> Uuid;
+  auto getPlayerDbId() const -> Uuid;
+
+  auto serialize(std::ostream &out) const -> std::ostream & override;
+  bool deserialize(std::istream &in) override;
+
+  auto clone() const -> IMessagePtr override;
+
+  private:
+  Uuid m_systemDbId{};
+  Uuid m_playerDbId{};
+};
+
+} // namespace bsgo

--- a/src/bsgo/messages/LoadingStartedMessage.cc
+++ b/src/bsgo/messages/LoadingStartedMessage.cc
@@ -1,0 +1,58 @@
+
+#include "LoadingStartedMessage.hh"
+#include "SerializationUtils.hh"
+
+namespace bsgo {
+
+LoadingStartedMessage::LoadingStartedMessage()
+  : NetworkMessage(MessageType::LOADING_STARTED)
+{}
+
+LoadingStartedMessage::LoadingStartedMessage(const Uuid systemDbId, const Uuid playerDbId)
+  : NetworkMessage(MessageType::LOADING_STARTED)
+  , m_systemDbId(systemDbId)
+  , m_playerDbId(playerDbId)
+{}
+
+auto LoadingStartedMessage::getSystemDbId() const -> Uuid
+{
+  return m_systemDbId;
+}
+
+auto LoadingStartedMessage::getPlayerDbId() const -> Uuid
+{
+  return m_playerDbId;
+}
+
+auto LoadingStartedMessage::serialize(std::ostream &out) const -> std::ostream &
+{
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+
+  core::serialize(out, m_systemDbId);
+  core::serialize(out, m_playerDbId);
+
+  return out;
+}
+
+bool LoadingStartedMessage::deserialize(std::istream &in)
+{
+  bool ok{true};
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+
+  ok &= core::deserialize(in, m_systemDbId);
+  ok &= core::deserialize(in, m_playerDbId);
+
+  return ok;
+}
+
+auto LoadingStartedMessage::clone() const -> IMessagePtr
+{
+  auto clone = std::make_unique<LoadingStartedMessage>(m_systemDbId, m_playerDbId);
+  clone->copyClientIdIfDefined(*this);
+
+  return clone;
+}
+
+} // namespace bsgo

--- a/src/bsgo/messages/LoadingStartedMessage.hh
+++ b/src/bsgo/messages/LoadingStartedMessage.hh
@@ -1,0 +1,29 @@
+
+#pragma once
+
+#include "NetworkMessage.hh"
+#include "Uuid.hh"
+
+namespace bsgo {
+
+class LoadingStartedMessage : public NetworkMessage
+{
+  public:
+  LoadingStartedMessage();
+  LoadingStartedMessage(const Uuid systemDbId, const Uuid playerDbId);
+  ~LoadingStartedMessage() override = default;
+
+  auto getSystemDbId() const -> Uuid;
+  auto getPlayerDbId() const -> Uuid;
+
+  auto serialize(std::ostream &out) const -> std::ostream & override;
+  bool deserialize(std::istream &in) override;
+
+  auto clone() const -> IMessagePtr override;
+
+  private:
+  Uuid m_systemDbId{};
+  Uuid m_playerDbId{};
+};
+
+} // namespace bsgo

--- a/src/bsgo/messages/MessageParser.cc
+++ b/src/bsgo/messages/MessageParser.cc
@@ -13,6 +13,8 @@
 #include "JumpCancelledMessage.hh"
 #include "JumpMessage.hh"
 #include "JumpRequestedMessage.hh"
+#include "LoadingFinishedMessage.hh"
+#include "LoadingStartedMessage.hh"
 #include "LoginMessage.hh"
 #include "LogoutMessage.hh"
 #include "LootMessage.hh"
@@ -117,6 +119,10 @@ auto MessageParser::tryReadMessage(const MessageType &type, std::istream &in)
       return readMessage<JumpCancelledMessage>(in);
     case MessageType::JUMP_REQUESTED:
       return readMessage<JumpRequestedMessage>(in);
+    case MessageType::LOADING_FINISHED:
+      return readMessage<LoadingFinishedMessage>(in);
+    case MessageType::LOADING_STARTED:
+      return readMessage<LoadingStartedMessage>(in);
     case MessageType::LOGIN:
       return readMessage<LoginMessage>(in);
     case MessageType::LOGOUT:

--- a/src/bsgo/messages/MessageType.cc
+++ b/src/bsgo/messages/MessageType.cc
@@ -27,6 +27,10 @@ auto str(const MessageType &type) -> std::string
       return "jump_cancelled";
     case MessageType::JUMP_REQUESTED:
       return "jump_requested";
+    case MessageType::LOADING_STARTED:
+      return "loading_started";
+    case MessageType::LOADING_FINISHED:
+      return "loading_finished";
     case MessageType::LOGIN:
       return "login";
     case MessageType::LOGOUT:
@@ -56,7 +60,7 @@ auto str(const MessageType &type) -> std::string
   }
 }
 
-auto allMessageTypes() -> std::array<MessageType, 22>
+auto allMessageTypes() -> std::array<MessageType, 24>
 {
   return {MessageType::COMPONENT_SYNC,
           MessageType::CONNECTION,
@@ -68,11 +72,13 @@ auto allMessageTypes() -> std::array<MessageType, 22>
           MessageType::JUMP,
           MessageType::JUMP_CANCELLED,
           MessageType::JUMP_REQUESTED,
+          MessageType::LOADING_STARTED,
+          MessageType::LOADING_FINISHED,
           MessageType::LOOT,
-          MessageType::PLAYER_LIST,
-          MessageType::PURCHASE,
           MessageType::LOGIN,
           MessageType::LOGOUT,
+          MessageType::PLAYER_LIST,
+          MessageType::PURCHASE,
           MessageType::SCANNED,
           MessageType::SIGNUP,
           MessageType::SLOT,

--- a/src/bsgo/messages/MessageType.hh
+++ b/src/bsgo/messages/MessageType.hh
@@ -19,6 +19,8 @@ enum class MessageType
   JUMP,
   JUMP_CANCELLED,
   JUMP_REQUESTED,
+  LOADING_STARTED,
+  LOADING_FINISHED,
   LOGIN,
   LOGOUT,
   LOOT,
@@ -34,7 +36,7 @@ enum class MessageType
 };
 
 auto str(const MessageType &type) -> std::string;
-auto allMessageTypes() -> std::array<MessageType, 22>;
+auto allMessageTypes() -> std::array<MessageType, 24>;
 
 auto allMessageTypesAsSet() -> std::unordered_set<MessageType>;
 

--- a/tests/unit/bsgo/messages/CMakeLists.txt
+++ b/tests/unit/bsgo/messages/CMakeLists.txt
@@ -19,6 +19,8 @@ target_sources(unitTests PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpCancelledMessageTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpMessageTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpRequestedMessageTest.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/LoadingStartedMessageTest.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/LoadingFinishedMessageTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LoginMessageTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LogoutMessageTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LootMessageTest.cc

--- a/tests/unit/bsgo/messages/LoadingFinishedMessageTest.cc
+++ b/tests/unit/bsgo/messages/LoadingFinishedMessageTest.cc
@@ -1,0 +1,51 @@
+
+#include "LoadingFinishedMessage.hh"
+#include "Common.hh"
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+namespace bsgo {
+namespace {
+auto assertMessagesAreEqual(const LoadingFinishedMessage &actual,
+                            const LoadingFinishedMessage &expected)
+{
+  EXPECT_EQ(actual.type(), expected.type());
+  EXPECT_EQ(actual.tryGetClientId(), expected.tryGetClientId());
+  EXPECT_EQ(actual.getSystemDbId(), expected.getSystemDbId());
+  EXPECT_EQ(actual.getPlayerDbId(), expected.getPlayerDbId());
+}
+} // namespace
+
+TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, Basic)
+{
+  const LoadingFinishedMessage expected(Uuid{1234}, Uuid{7845});
+
+  LoadingFinishedMessage actual(Uuid{4}, Uuid{54});
+  actual.setClientId(Uuid{12});
+
+  serializeAndDeserializeMessage(expected, actual);
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, WithClientId)
+{
+  LoadingFinishedMessage expected(Uuid{92}, Uuid{156});
+  expected.setClientId(Uuid{17});
+
+  LoadingFinishedMessage actual(Uuid{10}, Uuid{7});
+
+  serializeAndDeserializeMessage(expected, actual);
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, Clone)
+{
+  const LoadingFinishedMessage expected(Uuid{98}, Uuid{57});
+  const auto cloned = expected.clone();
+
+  ASSERT_EQ(cloned->type(), MessageType::LOADING_FINISHED);
+  assertMessagesAreEqual(cloned->as<LoadingFinishedMessage>(), expected);
+}
+
+} // namespace bsgo

--- a/tests/unit/bsgo/messages/LoadingStartedMessageTest.cc
+++ b/tests/unit/bsgo/messages/LoadingStartedMessageTest.cc
@@ -1,0 +1,51 @@
+
+#include "LoadingStartedMessage.hh"
+#include "Common.hh"
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+namespace bsgo {
+namespace {
+auto assertMessagesAreEqual(const LoadingStartedMessage &actual,
+                            const LoadingStartedMessage &expected)
+{
+  EXPECT_EQ(actual.type(), expected.type());
+  EXPECT_EQ(actual.tryGetClientId(), expected.tryGetClientId());
+  EXPECT_EQ(actual.getSystemDbId(), expected.getSystemDbId());
+  EXPECT_EQ(actual.getPlayerDbId(), expected.getPlayerDbId());
+}
+} // namespace
+
+TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, Basic)
+{
+  const LoadingStartedMessage expected(Uuid{1234}, Uuid{7845});
+
+  LoadingStartedMessage actual(Uuid{4}, Uuid{54});
+  actual.setClientId(Uuid{12});
+
+  serializeAndDeserializeMessage(expected, actual);
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, WithClientId)
+{
+  LoadingStartedMessage expected(Uuid{92}, Uuid{156});
+  expected.setClientId(Uuid{17});
+
+  LoadingStartedMessage actual(Uuid{10}, Uuid{7});
+
+  serializeAndDeserializeMessage(expected, actual);
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, Clone)
+{
+  const LoadingStartedMessage expected(Uuid{98}, Uuid{57});
+  const auto cloned = expected.clone();
+
+  ASSERT_EQ(cloned->type(), MessageType::LOADING_STARTED);
+  assertMessagesAreEqual(cloned->as<LoadingStartedMessage>(), expected);
+}
+
+} // namespace bsgo


### PR DESCRIPTION
# Work

## Context

The client application is currently loading most of the data directly from the database. This is not ideal for several reasons, the main one being that in a client/server architecture it would force to expose the database connection to the outside world.

## How to fix it?

Loading the data when a client connects to the server should follow the same logic as for the rest of the data: through messages. In order to do this, we first need to make the server able to produce such messages.

**Note:** the plan is laid out in more details in #9.

## Key changes for this PR

In this PR, we add two new message types:
* `LoadingStartedMessage`
* `LoadingFinishedMessage`

Those messages will be used in follow-up PRs to communicate the beginning and end of the loading process for a client. The actual data will be communicated by other (yet to come) messages and will be boxed by those two messages. In this way, the client application has a way to determine whether it should enter/exit the loading screen and potentially react in case some messages are lost.

# Tests

Some preliminary testing was done in #9 where a POC was implemented.

# Future work

Those messages need to be used as part of the loading process.
