### PR TITLE
feat: Wired loading started/finished messages in server

### DIFF
--- a/src/server/lib/consumers/input/LoginMessageConsumer.hh
+++ b/src/server/lib/consumers/input/LoginMessageConsumer.hh
@@ -6,6 +6,7 @@
 #include "IMessageQueue.hh"
 #include "LoginMessage.hh"
 #include "LoginService.hh"
+#include "SystemProcessor.hh"
 
 namespace bsgo {
 
@@ -14,6 +15,7 @@ class LoginMessageConsumer : public AbstractMessageConsumer
   public:
   LoginMessageConsumer(LoginServicePtr loginService,
                        ClientManagerShPtr clientManager,
+                       SystemProcessorMap systemProcessors,
                        IMessageQueue *const messageQueue);
   ~LoginMessageConsumer() override = default;
 
@@ -21,10 +23,12 @@ class LoginMessageConsumer : public AbstractMessageConsumer
 
   private:
   LoginServicePtr m_loginService{};
+  SystemProcessorMap m_systemProcessors{};
   ClientManagerShPtr m_clientManager{};
   IMessageQueue *const m_messageQueue{};
 
   void handleLogin(const LoginMessage &message) const;
+  void publishLoadingMessages(const bsgo::Uuid clientId, const bsgo::Uuid playerDbId) const;
 };
 
 } // namespace bsgo

--- a/src/server/lib/consumers/internal/EntityRemovedMessageConsumer.cc
+++ b/src/server/lib/consumers/internal/EntityRemovedMessageConsumer.cc
@@ -1,5 +1,6 @@
 
 #include "EntityRemovedMessageConsumer.hh"
+#include "EntityRemovedMessage.hh"
 #include "SystemProcessorUtils.hh"
 
 namespace bsgo {
@@ -14,13 +15,13 @@ EntityRemovedMessageConsumer::EntityRemovedMessageConsumer(SystemServiceShPtr sy
 {
   addModule("removed");
 
-  if (nullptr == m_messageQueue)
-  {
-    throw std::invalid_argument("Expected non null message queue");
-  }
   if (nullptr == m_systemService)
   {
     throw std::invalid_argument("Expected non null system service");
+  }
+  if (nullptr == m_messageQueue)
+  {
+    throw std::invalid_argument("Expected non null message queue");
   }
 }
 

--- a/src/server/lib/consumers/internal/EntityRemovedMessageConsumer.hh
+++ b/src/server/lib/consumers/internal/EntityRemovedMessageConsumer.hh
@@ -2,7 +2,6 @@
 #pragma once
 
 #include "AbstractMessageConsumer.hh"
-#include "EntityRemovedMessage.hh"
 #include "IMessageQueue.hh"
 #include "SystemProcessor.hh"
 #include "SystemService.hh"

--- a/src/server/lib/consumers/system/CMakeLists.txt
+++ b/src/server/lib/consumers/system/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources (server_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/HangarMessageConsumer.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpCancelledMessageConsumer.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpRequestedMessageConsumer.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/LoadingMessagesConsumer.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/PurchaseMessageConsumer.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/SlotMessageConsumer.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/TargetMessageConsumer.cc

--- a/src/server/lib/consumers/system/LoadingMessagesConsumer.cc
+++ b/src/server/lib/consumers/system/LoadingMessagesConsumer.cc
@@ -1,0 +1,52 @@
+
+#include "LoadingMessagesConsumer.hh"
+#include "SystemProcessorUtils.hh"
+
+namespace bsgo {
+
+LoadingMessagesConsumer::LoadingMessagesConsumer(const Services & /*services*/,
+                                                 IMessageQueue *const messageQueue)
+  : AbstractMessageConsumer("loading", {MessageType::LOADING_FINISHED, MessageType::LOADING_STARTED})
+  , m_messageQueue(messageQueue)
+{
+  if (nullptr == m_messageQueue)
+  {
+    throw std::invalid_argument("Expected non null message queue");
+  }
+}
+
+void LoadingMessagesConsumer::onMessageReceived(const IMessage &message)
+{
+  switch (message.type())
+  {
+    case MessageType::LOADING_STARTED:
+      forwardLoadingStartedMessage(message.as<LoadingStartedMessage>());
+      return;
+    case MessageType::LOADING_FINISHED:
+      forwardLoadingFinishedMessage(message.as<LoadingFinishedMessage>());
+      return;
+    default:
+      error("Unsupported loading operation " + str(message.type()));
+      break;
+  }
+}
+
+void LoadingMessagesConsumer::forwardLoadingStartedMessage(const LoadingStartedMessage &message) const
+{
+  auto out = std::make_unique<LoadingStartedMessage>(message.getSystemDbId(),
+                                                     message.getPlayerDbId());
+  out->copyClientIdIfDefined(message);
+
+  m_messageQueue->pushMessage(std::move(out));
+}
+
+void LoadingMessagesConsumer::forwardLoadingFinishedMessage(
+  const LoadingFinishedMessage &message) const
+{
+  auto out = std::make_unique<LoadingFinishedMessage>();
+  out->copyClientIdIfDefined(message);
+
+  m_messageQueue->pushMessage(std::move(out));
+}
+
+} // namespace bsgo

--- a/src/server/lib/consumers/system/LoadingMessagesConsumer.hh
+++ b/src/server/lib/consumers/system/LoadingMessagesConsumer.hh
@@ -1,0 +1,28 @@
+
+#pragma once
+
+#include "AbstractMessageConsumer.hh"
+#include "IMessageQueue.hh"
+#include "LoadingFinishedMessage.hh"
+#include "LoadingStartedMessage.hh"
+#include "PlayerListMessage.hh"
+#include "Services.hh"
+
+namespace bsgo {
+
+class LoadingMessagesConsumer : public AbstractMessageConsumer
+{
+  public:
+  LoadingMessagesConsumer(const Services &services, IMessageQueue *const messageQueue);
+  ~LoadingMessagesConsumer() override = default;
+
+  void onMessageReceived(const IMessage &message) override;
+
+  private:
+  IMessageQueue *const m_messageQueue{};
+
+  void forwardLoadingStartedMessage(const LoadingStartedMessage &message) const;
+  void forwardLoadingFinishedMessage(const LoadingFinishedMessage &message) const;
+};
+
+} // namespace bsgo

--- a/src/server/lib/game/MessageConsumerSetup.cc
+++ b/src/server/lib/game/MessageConsumerSetup.cc
@@ -8,6 +8,7 @@
 #include "HangarMessageConsumer.hh"
 #include "JumpCancelledMessageConsumer.hh"
 #include "JumpRequestedMessageConsumer.hh"
+#include "LoadingMessagesConsumer.hh"
 #include "PurchaseMessageConsumer.hh"
 #include "SlotMessageConsumer.hh"
 #include "TargetMessageConsumer.hh"
@@ -51,6 +52,9 @@ void createMessageConsumers(IMessageQueue &inputMessagesQueue,
 
   inputMessagesQueue.addListener(
     std::make_unique<EntityAddedMessageConsumer>(services, outputMessagesQueue));
+
+  inputMessagesQueue.addListener(
+    std::make_unique<LoadingMessagesConsumer>(services, outputMessagesQueue));
 }
 
 } // namespace bsgo

--- a/src/server/lib/game/MessageExchanger.cc
+++ b/src/server/lib/game/MessageExchanger.cc
@@ -104,10 +104,9 @@ auto MessageExchanger::initializeSystemMessageQueue(const MessageSystemData &mes
                                                                    m_outputMessageQueue.get()));
 
   auto loginService = std::make_unique<LoginService>(repositories);
-  // TODO: We could modify the LoginMessageConsumer to also receive the system processors
-  // and send a message in the corresponding system
   systemQueue->addListener(std::make_unique<LoginMessageConsumer>(std::move(loginService),
                                                                   messagesData.clientManager,
+                                                                  messagesData.systemProcessors,
                                                                   m_outputMessageQueue.get()));
 
   auto systemService = std::make_shared<SystemService>(repositories);


### PR DESCRIPTION
# Work

## Context

The client application is currently loading most of the data directly from the database. This is not ideal for several reasons, the main one being that in a client/server architecture it would force to expose the database connection to the outside world.

## How to fix it?

Loading the data when a client connects to the server should follow the same logic as for the rest of the data: through messages. In order to do this, we first need to make the server able to produce such messages.

**Note:** the plan is laid out in more details in #9.

## Key changes in this PR

In this PR, we build on what was brought by #11 and wire those messages in the server so that they are sent to the client. This can be done by slightly modifying the way the login flow works. This can be summarized by the two diagrams below.

### Old architecture for the login flow

![messaging-system-old](https://github.com/user-attachments/assets/1582e695-9354-4999-8e70-603a1eda105a)

### Proposed architecture for the login flow

![messaging-system-new](https://github.com/user-attachments/assets/c394f18e-ca02-416a-88e8-449c1b70a95a)

# Tests

Some preliminary testing was done in #9 where a POC was implemented. We could also verify locally that the client app receives the messages:

![image](https://github.com/user-attachments/assets/b7632365-cb17-4ab5-b362-6bde5736d062)

# Future work

We need to add some other messages to the login flow to send the data to the client application.
