### PR TITLE
feat: Added workflow to trigger on PR closed

### DIFF
--- a/.github/workflows/clean-branch-action-cache.yml
+++ b/.github/workflows/clean-branch-action-cache.yml
@@ -12,14 +12,11 @@ jobs:
     permissions:
       actions: write
     steps:
-      - name: Debug
+      - name: Print PR information
         run: |
-          echo The PR was merged
-          echo "base ref: ${{ github.base_ref }}"
-          echo "head ref: ${{ github.head_ref }}"
-          echo "ref: ${{ github.ref }}"
-          echo "ref name: ${{ github.ref_name }}"
-          echo "branch: refs/pull/${{ github.event.pull_request.number }}/merge"
+          echo "Base ref:: ${{ github.base_ref }}"
+          echo "Head ref: ${{ github.head_ref }}"
+          echo "Proceeding with ref: refs/heads/${{ github.head_ref }}:"
       - name: Clean cache
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
         run: |

--- a/.github/workflows/clean-branch-action-cache.yml
+++ b/.github/workflows/clean-branch-action-cache.yml
@@ -13,7 +13,7 @@ jobs:
       actions: write
     steps:
       - name: Debug
-      - run: |
+        run: |
           echo The PR was merged
           echo "base ref: ${{ github.base_ref }}"
           echo "head ref: ${{ github.head_ref }}"

--- a/.github/workflows/clean-branch-action-cache.yml
+++ b/.github/workflows/clean-branch-action-cache.yml
@@ -26,15 +26,18 @@ jobs:
           echo "Fetching list of cache keys"
           cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
 
+          echo "Found $(echo "$cacheKeysForPR" | wc -l) cache keys to delete for branch $BRANCH"
+
           ## Setting this to not fail the workflow while deleting cache keys.
           set +e
+
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              gh cache delete $cacheKey
+            gh cache delete $cacheKey
           done
           echo "Done"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+          BRANCH: refs/heads/${{ github.head_ref }}

--- a/.github/workflows/clean-branch-action-cache.yml
+++ b/.github/workflows/clean-branch-action-cache.yml
@@ -1,0 +1,18 @@
+name: Clean GitHub actions cache for branch
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo The PR was merged
+          echo "base ref: ${{ github.base_ref }}"
+          echo "head ref: ${{ github.head_ref }}"
+          echo "ref: ${{ github.ref }}"
+          echo "ref name: ${{ github.ref_name }}"

--- a/.github/workflows/clean-branch-action-cache.yml
+++ b/.github/workflows/clean-branch-action-cache.yml
@@ -7,12 +7,34 @@ on:
       - closed
 
 jobs:
-  if_merged:
+  clean-action-cache:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
+      - name: Debug
       - run: |
           echo The PR was merged
           echo "base ref: ${{ github.base_ref }}"
           echo "head ref: ${{ github.head_ref }}"
           echo "ref: ${{ github.ref }}"
           echo "ref name: ${{ github.ref_name }}"
+          echo "branch: refs/pull/${{ github.event.pull_request.number }}/merge"
+      - name: Clean cache
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/tests/unit/bsgo/messages/DockMessageTest.cc
+++ b/tests/unit/bsgo/messages/DockMessageTest.cc
@@ -7,6 +7,7 @@ using namespace ::testing;
 
 namespace bsgo {
 namespace {
+// Dummy change
 auto assertMessagesAreEqual(const DockMessage &actual, const DockMessage &expected)
 {
   EXPECT_EQ(actual.type(), expected.type());

--- a/tests/unit/bsgo/messages/DockMessageTest.cc
+++ b/tests/unit/bsgo/messages/DockMessageTest.cc
@@ -7,7 +7,7 @@ using namespace ::testing;
 
 namespace bsgo {
 namespace {
-// Dummy change
+// Dummy change 2
 auto assertMessagesAreEqual(const DockMessage &actual, const DockMessage &expected)
 {
   EXPECT_EQ(actual.type(), expected.type());

--- a/tests/unit/bsgo/messages/DockMessageTest.cc
+++ b/tests/unit/bsgo/messages/DockMessageTest.cc
@@ -7,7 +7,6 @@ using namespace ::testing;
 
 namespace bsgo {
 namespace {
-// Dummy change 3
 auto assertMessagesAreEqual(const DockMessage &actual, const DockMessage &expected)
 {
   EXPECT_EQ(actual.type(), expected.type());

--- a/tests/unit/bsgo/messages/DockMessageTest.cc
+++ b/tests/unit/bsgo/messages/DockMessageTest.cc
@@ -7,7 +7,7 @@ using namespace ::testing;
 
 namespace bsgo {
 namespace {
-// Dummy change 2
+// Dummy change 3
 auto assertMessagesAreEqual(const DockMessage &actual, const DockMessage &expected)
 {
   EXPECT_EQ(actual.type(), expected.type());


### PR DESCRIPTION
# Work

## Context

In #14 we improved the use of `actions/restore` and `actions/save` to create a cache per commit. This might generate a lot of cached data. Additionally as we have one cache per commit, the cached data is never reused except by the commit immediately after the one that generated the cache.

GitHub already has a mechanism to clean up stale caches after 7 days (see [source](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)). We can improve this logic a bit by cleaning up the cached data for a branch when a PR is closed.

# Tests

When merging #17, the new workflow was triggered. The debug info is the following:
```
 The PR was merged
base ref: ci/clean-action-cache-on-pr-merged
head ref: chore/attempt-to-create-branch-2
ref: refs/heads/ci/clean-action-cache-on-pr-merged
ref name: ci/clean-action-cache-on-pr-merged
branch: refs/pull/17/merge
```

However it seems like the list command did not return any result (when executing locally):
```bash
~/$ gh cache list --ref refs/pull/17/merge --limit 100 --json id
[]
```

Running the command for the head ref yields some result though:
```bash
~/$ gh cache list --ref refs/heads/chore/attempt-to-create-branch-2 --limit 100 --json id
[
  {
    "id": 514676539
  },
  {
    "id": 514661692
  }
]
```

Merging #18 successfully deleted the cache associated to the branch:

![image](https://github.com/user-attachments/assets/1dbd9301-6a1d-410c-a9d5-6c167fe25453)

![image](https://github.com/user-attachments/assets/9f17a06d-5212-4181-8c48-71c3c10ad6b1)

# Future work
