### PR TITLE
feat: Emit loading messages when undocking

### DIFF
--- a/src/bsgo/messages/LoadingFinishedMessage.cc
+++ b/src/bsgo/messages/LoadingFinishedMessage.cc
@@ -8,6 +8,11 @@ LoadingFinishedMessage::LoadingFinishedMessage()
   : NetworkMessage(MessageType::LOADING_FINISHED)
 {}
 
+LoadingFinishedMessage::LoadingFinishedMessage(const Uuid systemDbId)
+  : NetworkMessage(MessageType::LOADING_FINISHED)
+  , m_systemDbId(systemDbId)
+{}
+
 LoadingFinishedMessage::LoadingFinishedMessage(const Uuid systemDbId, const Uuid playerDbId)
   : NetworkMessage(MessageType::LOADING_FINISHED)
   , m_systemDbId(systemDbId)
@@ -19,7 +24,7 @@ auto LoadingFinishedMessage::getSystemDbId() const -> Uuid
   return m_systemDbId;
 }
 
-auto LoadingFinishedMessage::getPlayerDbId() const -> Uuid
+auto LoadingFinishedMessage::tryGetPlayerDbId() const -> std::optional<Uuid>
 {
   return m_playerDbId;
 }
@@ -49,7 +54,17 @@ bool LoadingFinishedMessage::deserialize(std::istream &in)
 
 auto LoadingFinishedMessage::clone() const -> IMessagePtr
 {
-  auto clone = std::make_unique<LoadingFinishedMessage>(m_systemDbId, m_playerDbId);
+  std::unique_ptr<LoadingFinishedMessage> clone{};
+
+  if (m_playerDbId)
+  {
+    clone = std::make_unique<LoadingFinishedMessage>(m_systemDbId, *m_playerDbId);
+  }
+  else
+  {
+    clone = std::make_unique<LoadingFinishedMessage>(m_systemDbId);
+  }
+
   clone->copyClientIdIfDefined(*this);
 
   return clone;

--- a/src/bsgo/messages/LoadingFinishedMessage.hh
+++ b/src/bsgo/messages/LoadingFinishedMessage.hh
@@ -10,11 +10,12 @@ class LoadingFinishedMessage : public NetworkMessage
 {
   public:
   LoadingFinishedMessage();
+  LoadingFinishedMessage(const Uuid systemDbId);
   LoadingFinishedMessage(const Uuid systemDbId, const Uuid playerDbId);
   ~LoadingFinishedMessage() override = default;
 
   auto getSystemDbId() const -> Uuid;
-  auto getPlayerDbId() const -> Uuid;
+  auto tryGetPlayerDbId() const -> std::optional<Uuid>;
 
   auto serialize(std::ostream &out) const -> std::ostream & override;
   bool deserialize(std::istream &in) override;
@@ -23,7 +24,7 @@ class LoadingFinishedMessage : public NetworkMessage
 
   private:
   Uuid m_systemDbId{};
-  Uuid m_playerDbId{};
+  std::optional<Uuid> m_playerDbId{};
 };
 
 } // namespace bsgo

--- a/src/bsgo/messages/LoadingStartedMessage.cc
+++ b/src/bsgo/messages/LoadingStartedMessage.cc
@@ -8,6 +8,11 @@ LoadingStartedMessage::LoadingStartedMessage()
   : NetworkMessage(MessageType::LOADING_STARTED)
 {}
 
+LoadingStartedMessage::LoadingStartedMessage(const Uuid systemDbId)
+  : NetworkMessage(MessageType::LOADING_STARTED)
+  , m_systemDbId(systemDbId)
+{}
+
 LoadingStartedMessage::LoadingStartedMessage(const Uuid systemDbId, const Uuid playerDbId)
   : NetworkMessage(MessageType::LOADING_STARTED)
   , m_systemDbId(systemDbId)
@@ -19,7 +24,7 @@ auto LoadingStartedMessage::getSystemDbId() const -> Uuid
   return m_systemDbId;
 }
 
-auto LoadingStartedMessage::getPlayerDbId() const -> Uuid
+auto LoadingStartedMessage::tryGetPlayerDbId() const -> std::optional<Uuid>
 {
   return m_playerDbId;
 }
@@ -49,7 +54,17 @@ bool LoadingStartedMessage::deserialize(std::istream &in)
 
 auto LoadingStartedMessage::clone() const -> IMessagePtr
 {
-  auto clone = std::make_unique<LoadingStartedMessage>(m_systemDbId, m_playerDbId);
+  std::unique_ptr<LoadingStartedMessage> clone{};
+
+  if (m_playerDbId)
+  {
+    clone = std::make_unique<LoadingStartedMessage>(m_systemDbId, *m_playerDbId);
+  }
+  else
+  {
+    clone = std::make_unique<LoadingStartedMessage>(m_systemDbId);
+  }
+
   clone->copyClientIdIfDefined(*this);
 
   return clone;

--- a/src/bsgo/messages/LoadingStartedMessage.hh
+++ b/src/bsgo/messages/LoadingStartedMessage.hh
@@ -10,11 +10,12 @@ class LoadingStartedMessage : public NetworkMessage
 {
   public:
   LoadingStartedMessage();
+  LoadingStartedMessage(const Uuid systemDbId);
   LoadingStartedMessage(const Uuid systemDbId, const Uuid playerDbId);
   ~LoadingStartedMessage() override = default;
 
   auto getSystemDbId() const -> Uuid;
-  auto getPlayerDbId() const -> Uuid;
+  auto tryGetPlayerDbId() const -> std::optional<Uuid>;
 
   auto serialize(std::ostream &out) const -> std::ostream & override;
   bool deserialize(std::istream &in) override;
@@ -23,7 +24,7 @@ class LoadingStartedMessage : public NetworkMessage
 
   private:
   Uuid m_systemDbId{};
-  Uuid m_playerDbId{};
+  std::optional<Uuid> m_playerDbId{};
 };
 
 } // namespace bsgo

--- a/src/server/lib/consumers/internal/JumpMessageConsumer.hh
+++ b/src/server/lib/consumers/internal/JumpMessageConsumer.hh
@@ -29,6 +29,7 @@ class JumpMessageConsumer : public AbstractMessageConsumer
   void handlePostJumpSystemMessages(const Uuid shipDbId,
                                     const Uuid sourceSystemDbId,
                                     const Uuid destinationSystemDbId);
+  void handleLoadingMessages(const Uuid playerDbId, const Uuid destinationSystemDbId);
 };
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/DockMessageConsumer.cc
+++ b/src/server/lib/consumers/system/DockMessageConsumer.cc
@@ -1,6 +1,8 @@
 
 #include "DockMessageConsumer.hh"
 #include "EntityAddedMessage.hh"
+#include "LoadingFinishedMessage.hh"
+#include "LoadingStartedMessage.hh"
 
 namespace bsgo {
 
@@ -73,6 +75,14 @@ void DockMessageConsumer::handleUndocking(const DockMessage &message) const
 
   auto added = std::make_unique<EntityAddedMessage>(shipDbId, EntityKind::SHIP, systemDbId);
   m_messageQueue->pushMessage(std::move(added));
+
+  auto started = std::make_unique<LoadingStartedMessage>(systemDbId);
+  started->copyClientIdIfDefined(message);
+  m_messageQueue->pushMessage(std::move(started));
+
+  auto finished = std::make_unique<LoadingFinishedMessage>(systemDbId);
+  finished->copyClientIdIfDefined(message);
+  m_messageQueue->pushMessage(std::move(finished));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/LoadingMessagesConsumer.cc
+++ b/src/server/lib/consumers/system/LoadingMessagesConsumer.cc
@@ -33,20 +33,13 @@ void LoadingMessagesConsumer::onMessageReceived(const IMessage &message)
 
 void LoadingMessagesConsumer::forwardLoadingStartedMessage(const LoadingStartedMessage &message) const
 {
-  auto out = std::make_unique<LoadingStartedMessage>(message.getSystemDbId(),
-                                                     message.getPlayerDbId());
-  out->copyClientIdIfDefined(message);
-
-  m_messageQueue->pushMessage(std::move(out));
+  m_messageQueue->pushMessage(message.clone());
 }
 
 void LoadingMessagesConsumer::forwardLoadingFinishedMessage(
   const LoadingFinishedMessage &message) const
 {
-  auto out = std::make_unique<LoadingFinishedMessage>();
-  out->copyClientIdIfDefined(message);
-
-  m_messageQueue->pushMessage(std::move(out));
+  m_messageQueue->pushMessage(message.clone());
 }
 
 } // namespace bsgo

--- a/tests/unit/bsgo/messages/LoadingFinishedMessageTest.cc
+++ b/tests/unit/bsgo/messages/LoadingFinishedMessageTest.cc
@@ -13,7 +13,7 @@ auto assertMessagesAreEqual(const LoadingFinishedMessage &actual,
   EXPECT_EQ(actual.type(), expected.type());
   EXPECT_EQ(actual.tryGetClientId(), expected.tryGetClientId());
   EXPECT_EQ(actual.getSystemDbId(), expected.getSystemDbId());
-  EXPECT_EQ(actual.getPlayerDbId(), expected.getPlayerDbId());
+  EXPECT_EQ(actual.tryGetPlayerDbId(), expected.tryGetPlayerDbId());
 }
 } // namespace
 
@@ -21,8 +21,18 @@ TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, Basic)
 {
   const LoadingFinishedMessage expected(Uuid{1234}, Uuid{7845});
 
-  LoadingFinishedMessage actual(Uuid{4}, Uuid{54});
+  LoadingFinishedMessage actual(Uuid{4});
   actual.setClientId(Uuid{12});
+
+  serializeAndDeserializeMessage(expected, actual);
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, WithoutPlayerDbId)
+{
+  const LoadingFinishedMessage expected(Uuid{32});
+
+  LoadingFinishedMessage actual(Uuid{489}, Uuid{6578});
 
   serializeAndDeserializeMessage(expected, actual);
   assertMessagesAreEqual(actual, expected);
@@ -42,6 +52,15 @@ TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, WithClientId)
 TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, Clone)
 {
   const LoadingFinishedMessage expected(Uuid{98}, Uuid{57});
+  const auto cloned = expected.clone();
+
+  ASSERT_EQ(cloned->type(), MessageType::LOADING_FINISHED);
+  assertMessagesAreEqual(cloned->as<LoadingFinishedMessage>(), expected);
+}
+
+TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, CloneWithoutPlayerDbId)
+{
+  const LoadingFinishedMessage expected(Uuid{37});
   const auto cloned = expected.clone();
 
   ASSERT_EQ(cloned->type(), MessageType::LOADING_FINISHED);

--- a/tests/unit/bsgo/messages/LoadingStartedMessageTest.cc
+++ b/tests/unit/bsgo/messages/LoadingStartedMessageTest.cc
@@ -13,7 +13,7 @@ auto assertMessagesAreEqual(const LoadingStartedMessage &actual,
   EXPECT_EQ(actual.type(), expected.type());
   EXPECT_EQ(actual.tryGetClientId(), expected.tryGetClientId());
   EXPECT_EQ(actual.getSystemDbId(), expected.getSystemDbId());
-  EXPECT_EQ(actual.getPlayerDbId(), expected.getPlayerDbId());
+  EXPECT_EQ(actual.tryGetPlayerDbId(), expected.tryGetPlayerDbId());
 }
 } // namespace
 
@@ -21,8 +21,18 @@ TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, Basic)
 {
   const LoadingStartedMessage expected(Uuid{1234}, Uuid{7845});
 
-  LoadingStartedMessage actual(Uuid{4}, Uuid{54});
+  LoadingStartedMessage actual(Uuid{4});
   actual.setClientId(Uuid{12});
+
+  serializeAndDeserializeMessage(expected, actual);
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, WithoutPlayerDbId)
+{
+  const LoadingStartedMessage expected(Uuid{32});
+
+  LoadingStartedMessage actual(Uuid{489}, Uuid{6578});
 
   serializeAndDeserializeMessage(expected, actual);
   assertMessagesAreEqual(actual, expected);
@@ -42,6 +52,15 @@ TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, WithClientId)
 TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, Clone)
 {
   const LoadingStartedMessage expected(Uuid{98}, Uuid{57});
+  const auto cloned = expected.clone();
+
+  ASSERT_EQ(cloned->type(), MessageType::LOADING_STARTED);
+  assertMessagesAreEqual(cloned->as<LoadingStartedMessage>(), expected);
+}
+
+TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, CloneWithoutPlayerDbId)
+{
+  const LoadingStartedMessage expected(Uuid{37});
   const auto cloned = expected.clone();
 
   ASSERT_EQ(cloned->type(), MessageType::LOADING_STARTED);


### PR DESCRIPTION
# Work

## Context

The client application is currently loading most of the data directly from the database. This is not ideal for several reasons, the main one being that in a client/server architecture it would force to expose the database connection to the outside world.

## How to fix it?

Loading the data when a client connects to the server should follow the same logic as for the rest of the data: through messages. In order to do this, we first need to make the server able to produce such messages.

**Note:** the plan is laid out in more details in #9.

## Key changes in this PR

In #12 the loading messages were added when a client logs into the game. Long term, this is what will allow to receive the shop's data, the locker's data and more generally all the data needed to build the outpost UI.

A missing step is when the user interacts with the game and needs to receive the current system's data. This can happen in two occasions:
* when the user undocks
* when the user jumps to another system

In this PR we add the set of `LoadingStartedMessage` and `LoadingFinishedMessage` to:
* the `DockMessageConsumer` to handle the undock operation
* the `JumpMessageConsumer` to handle jumping to another system

# Tests

Verifying locally we get the messages when undocking:

![image](https://github.com/user-attachments/assets/1173fba3-5ca7-458f-8317-0ae2d6b67005)

And when arriving to a new system:

![image](https://github.com/user-attachments/assets/c9c477bf-754b-4c3b-bad2-b3328e61d679)

# Future work
