### PR TITLE
feat: Added loading transitions

### DIFF
--- a/src/bsgo/enums/CMakeLists.txt
+++ b/src/bsgo/enums/CMakeLists.txt
@@ -1,12 +1,13 @@
 
 target_sources (bsgo_lib PRIVATE
-	${CMAKE_CURRENT_SOURCE_DIR}/Uuid.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/EntityKind.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/Faction.cc
-	${CMAKE_CURRENT_SOURCE_DIR}/Slot.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/Item.cc
-	${CMAKE_CURRENT_SOURCE_DIR}/Status.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/LoadingTransition.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/ShipClass.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/Slot.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/Status.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/Uuid.cc
 	)
 
 target_include_directories (bsgo_lib PUBLIC

--- a/src/bsgo/enums/LoadingTransition.cc
+++ b/src/bsgo/enums/LoadingTransition.cc
@@ -1,0 +1,21 @@
+
+#include "LoadingTransition.hh"
+
+namespace bsgo {
+
+auto str(const LoadingTransition transition) -> std::string
+{
+  switch (transition)
+  {
+    case LoadingTransition::JUMP:
+      return "jump";
+    case LoadingTransition::LOGIN:
+      return "login";
+    case LoadingTransition::UNDOCK:
+      return "undock";
+    default:
+      return "unknown";
+  }
+}
+
+} // namespace bsgo

--- a/src/bsgo/enums/LoadingTransition.hh
+++ b/src/bsgo/enums/LoadingTransition.hh
@@ -1,0 +1,17 @@
+
+#pragma once
+
+#include <string>
+
+namespace bsgo {
+
+enum class LoadingTransition
+{
+  JUMP,
+  LOGIN,
+  UNDOCK,
+};
+
+auto str(const LoadingTransition transition) -> std::string;
+
+} // namespace bsgo

--- a/src/bsgo/messages/loading/LoadingFinishedMessage.cc
+++ b/src/bsgo/messages/loading/LoadingFinishedMessage.cc
@@ -8,16 +8,26 @@ LoadingFinishedMessage::LoadingFinishedMessage()
   : NetworkMessage(MessageType::LOADING_FINISHED)
 {}
 
-LoadingFinishedMessage::LoadingFinishedMessage(const Uuid systemDbId)
+LoadingFinishedMessage::LoadingFinishedMessage(const LoadingTransition transition,
+                                               const Uuid systemDbId)
   : NetworkMessage(MessageType::LOADING_FINISHED)
+  , m_transition(transition)
   , m_systemDbId(systemDbId)
 {}
 
-LoadingFinishedMessage::LoadingFinishedMessage(const Uuid systemDbId, const Uuid playerDbId)
+LoadingFinishedMessage::LoadingFinishedMessage(const LoadingTransition transition,
+                                               const Uuid systemDbId,
+                                               const Uuid playerDbId)
   : NetworkMessage(MessageType::LOADING_FINISHED)
+  , m_transition(transition)
   , m_systemDbId(systemDbId)
   , m_playerDbId(playerDbId)
 {}
+
+auto LoadingFinishedMessage::getTransition() const -> LoadingTransition
+{
+  return m_transition;
+}
 
 auto LoadingFinishedMessage::getSystemDbId() const -> Uuid
 {
@@ -34,6 +44,7 @@ auto LoadingFinishedMessage::serialize(std::ostream &out) const -> std::ostream 
   core::serialize(out, m_messageType);
   core::serialize(out, m_clientId);
 
+  core::serialize(out, m_transition);
   core::serialize(out, m_systemDbId);
   core::serialize(out, m_playerDbId);
 
@@ -46,6 +57,7 @@ bool LoadingFinishedMessage::deserialize(std::istream &in)
   ok &= core::deserialize(in, m_messageType);
   ok &= core::deserialize(in, m_clientId);
 
+  ok &= core::deserialize(in, m_transition);
   ok &= core::deserialize(in, m_systemDbId);
   ok &= core::deserialize(in, m_playerDbId);
 
@@ -58,11 +70,11 @@ auto LoadingFinishedMessage::clone() const -> IMessagePtr
 
   if (m_playerDbId)
   {
-    clone = std::make_unique<LoadingFinishedMessage>(m_systemDbId, *m_playerDbId);
+    clone = std::make_unique<LoadingFinishedMessage>(m_transition, m_systemDbId, *m_playerDbId);
   }
   else
   {
-    clone = std::make_unique<LoadingFinishedMessage>(m_systemDbId);
+    clone = std::make_unique<LoadingFinishedMessage>(m_transition, m_systemDbId);
   }
 
   clone->copyClientIdIfDefined(*this);

--- a/src/bsgo/messages/loading/LoadingFinishedMessage.hh
+++ b/src/bsgo/messages/loading/LoadingFinishedMessage.hh
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "LoadingTransition.hh"
 #include "NetworkMessage.hh"
 #include "Uuid.hh"
 
@@ -10,10 +11,13 @@ class LoadingFinishedMessage : public NetworkMessage
 {
   public:
   LoadingFinishedMessage();
-  LoadingFinishedMessage(const Uuid systemDbId);
-  LoadingFinishedMessage(const Uuid systemDbId, const Uuid playerDbId);
+  LoadingFinishedMessage(const LoadingTransition transition, const Uuid systemDbId);
+  LoadingFinishedMessage(const LoadingTransition transition,
+                         const Uuid systemDbId,
+                         const Uuid playerDbId);
   ~LoadingFinishedMessage() override = default;
 
+  auto getTransition() const -> LoadingTransition;
   auto getSystemDbId() const -> Uuid;
   auto tryGetPlayerDbId() const -> std::optional<Uuid>;
 
@@ -23,6 +27,7 @@ class LoadingFinishedMessage : public NetworkMessage
   auto clone() const -> IMessagePtr override;
 
   private:
+  LoadingTransition m_transition{};
   Uuid m_systemDbId{};
   std::optional<Uuid> m_playerDbId{};
 };

--- a/src/bsgo/messages/loading/LoadingStartedMessage.cc
+++ b/src/bsgo/messages/loading/LoadingStartedMessage.cc
@@ -8,16 +8,26 @@ LoadingStartedMessage::LoadingStartedMessage()
   : NetworkMessage(MessageType::LOADING_STARTED)
 {}
 
-LoadingStartedMessage::LoadingStartedMessage(const Uuid systemDbId)
+LoadingStartedMessage::LoadingStartedMessage(const LoadingTransition transition,
+                                             const Uuid systemDbId)
   : NetworkMessage(MessageType::LOADING_STARTED)
+  , m_transition(transition)
   , m_systemDbId(systemDbId)
 {}
 
-LoadingStartedMessage::LoadingStartedMessage(const Uuid systemDbId, const Uuid playerDbId)
+LoadingStartedMessage::LoadingStartedMessage(const LoadingTransition transition,
+                                             const Uuid systemDbId,
+                                             const Uuid playerDbId)
   : NetworkMessage(MessageType::LOADING_STARTED)
+  , m_transition(transition)
   , m_systemDbId(systemDbId)
   , m_playerDbId(playerDbId)
 {}
+
+auto LoadingStartedMessage::getTransition() const -> LoadingTransition
+{
+  return m_transition;
+}
 
 auto LoadingStartedMessage::getSystemDbId() const -> Uuid
 {
@@ -34,6 +44,7 @@ auto LoadingStartedMessage::serialize(std::ostream &out) const -> std::ostream &
   core::serialize(out, m_messageType);
   core::serialize(out, m_clientId);
 
+  core::serialize(out, m_transition);
   core::serialize(out, m_systemDbId);
   core::serialize(out, m_playerDbId);
 
@@ -46,6 +57,7 @@ bool LoadingStartedMessage::deserialize(std::istream &in)
   ok &= core::deserialize(in, m_messageType);
   ok &= core::deserialize(in, m_clientId);
 
+  ok &= core::deserialize(in, m_transition);
   ok &= core::deserialize(in, m_systemDbId);
   ok &= core::deserialize(in, m_playerDbId);
 
@@ -58,11 +70,11 @@ auto LoadingStartedMessage::clone() const -> IMessagePtr
 
   if (m_playerDbId)
   {
-    clone = std::make_unique<LoadingStartedMessage>(m_systemDbId, *m_playerDbId);
+    clone = std::make_unique<LoadingStartedMessage>(m_transition, m_systemDbId, *m_playerDbId);
   }
   else
   {
-    clone = std::make_unique<LoadingStartedMessage>(m_systemDbId);
+    clone = std::make_unique<LoadingStartedMessage>(m_transition, m_systemDbId);
   }
 
   clone->copyClientIdIfDefined(*this);

--- a/src/bsgo/messages/loading/LoadingStartedMessage.hh
+++ b/src/bsgo/messages/loading/LoadingStartedMessage.hh
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "LoadingTransition.hh"
 #include "NetworkMessage.hh"
 #include "Uuid.hh"
 
@@ -10,10 +11,13 @@ class LoadingStartedMessage : public NetworkMessage
 {
   public:
   LoadingStartedMessage();
-  LoadingStartedMessage(const Uuid systemDbId);
-  LoadingStartedMessage(const Uuid systemDbId, const Uuid playerDbId);
+  LoadingStartedMessage(const LoadingTransition transition, const Uuid systemDbId);
+  LoadingStartedMessage(const LoadingTransition transition,
+                        const Uuid systemDbId,
+                        const Uuid playerDbId);
   ~LoadingStartedMessage() override = default;
 
+  auto getTransition() const -> LoadingTransition;
   auto getSystemDbId() const -> Uuid;
   auto tryGetPlayerDbId() const -> std::optional<Uuid>;
 
@@ -23,6 +27,7 @@ class LoadingStartedMessage : public NetworkMessage
   auto clone() const -> IMessagePtr override;
 
   private:
+  LoadingTransition m_transition{};
   Uuid m_systemDbId{};
   std::optional<Uuid> m_playerDbId{};
 };

--- a/src/client/lib/game/Game.cc
+++ b/src/client/lib/game/Game.cc
@@ -343,20 +343,25 @@ void Game::onPlayerKilled()
   }
 }
 
-void Game::onLoadingStarted()
+void Game::onLoadingStarted(const bsgo::LoadingTransition transition)
 {
   if (m_state.screen != Screen::LOADING)
   {
     error("Unexpected loading started event", "Not in loading screen");
   }
   debug("Starting loading transition to " + str(*m_gameSession.nextScreen));
+  m_gameSession.transition = transition;
 }
 
-void Game::onLoadingFinished()
+void Game::onLoadingFinished(const bsgo::LoadingTransition transition)
 {
   if (m_state.screen != Screen::LOADING)
   {
     error("Unexpected loading finished event", "Not in loading screen");
+  }
+  if (!m_gameSession.transition || *m_gameSession.transition != transition)
+  {
+    error("Unexpected loading finished event", "Transition does not match");
   }
   if (!m_gameSession.nextScreen || !m_gameSession.previousScreen)
   {

--- a/src/client/lib/game/Game.hh
+++ b/src/client/lib/game/Game.hh
@@ -10,6 +10,7 @@
 #include "IInputHandler.hh"
 #include "IRenderer.hh"
 #include "IUiHandler.hh"
+#include "LoadingTransition.hh"
 #include "RenderState.hh"
 #include "Renderer.hh"
 #include "RenderingPass.hh"
@@ -67,8 +68,8 @@ class Game : public core::CoreObject
   void onShipDocked();
   void onShipUndocked();
   void onPlayerKilled();
-  void onLoadingStarted();
-  void onLoadingFinished();
+  void onLoadingStarted(const bsgo::LoadingTransition transition);
+  void onLoadingFinished(const bsgo::LoadingTransition transition);
 
   private:
   /// @brief - Convenience information defining the state of the
@@ -97,6 +98,8 @@ class Game : public core::CoreObject
   {
     std::optional<bsgo::Uuid> systemDbId{};
     std::optional<bsgo::Uuid> playerDbId{};
+
+    std::optional<bsgo::LoadingTransition> transition{};
 
     /// @brief - holds the screen that was displayed before the current
     /// loading phase.

--- a/src/client/lib/game/GameMessageModule.cc
+++ b/src/client/lib/game/GameMessageModule.cc
@@ -154,16 +154,14 @@ void GameMessageModule::handleEntityRemovedMessage(const bsgo::EntityRemovedMess
   }
 }
 
-void GameMessageModule::handleLoadingStartedMessage(
-  const bsgo::LoadingStartedMessage & /*message*/) const
+void GameMessageModule::handleLoadingStartedMessage(const bsgo::LoadingStartedMessage &message) const
 {
-  m_game.onLoadingStarted();
+  m_game.onLoadingStarted(message.getTransition());
 }
 
-void GameMessageModule::handleLoadingFinishedMessage(
-  const bsgo::LoadingFinishedMessage & /*message*/) const
+void GameMessageModule::handleLoadingFinishedMessage(const bsgo::LoadingFinishedMessage &message) const
 {
-  m_game.onLoadingFinished();
+  m_game.onLoadingFinished(message.getTransition());
 }
 
 } // namespace pge

--- a/src/server/lib/consumers/input/LoginMessageConsumer.cc
+++ b/src/server/lib/consumers/input/LoginMessageConsumer.cc
@@ -81,11 +81,15 @@ void LoginMessageConsumer::publishLoadingMessages(const bsgo::Uuid clientId,
           "Unknown system " + str(*maybeSystemDbId));
   }
 
-  auto started = std::make_unique<LoadingStartedMessage>(*maybeSystemDbId, playerDbId);
+  auto started = std::make_unique<LoadingStartedMessage>(LoadingTransition::LOGIN,
+                                                         *maybeSystemDbId,
+                                                         playerDbId);
   started->setClientId(clientId);
   maybeProcessor->second->pushMessage(std::move(started));
 
-  auto finished = std::make_unique<LoadingFinishedMessage>(*maybeSystemDbId, playerDbId);
+  auto finished = std::make_unique<LoadingFinishedMessage>(LoadingTransition::LOGIN,
+                                                           *maybeSystemDbId,
+                                                           playerDbId);
   finished->setClientId(clientId);
   maybeProcessor->second->pushMessage(std::move(finished));
 }

--- a/src/server/lib/consumers/internal/JumpMessageConsumer.cc
+++ b/src/server/lib/consumers/internal/JumpMessageConsumer.cc
@@ -101,10 +101,14 @@ void JumpMessageConsumer::handleLoadingMessages(const Uuid playerDbId,
 
   debug("Pushing loading messages to " + str(destinationSystemDbId));
 
-  auto started = std::make_unique<LoadingStartedMessage>(destinationSystemDbId, playerDbId);
+  auto started = std::make_unique<LoadingStartedMessage>(LoadingTransition::JUMP,
+                                                         destinationSystemDbId,
+                                                         playerDbId);
   maybeDestinationProcessor->second->pushMessage(std::move(started));
 
-  auto finished = std::make_unique<LoadingFinishedMessage>(destinationSystemDbId, playerDbId);
+  auto finished = std::make_unique<LoadingFinishedMessage>(LoadingTransition::JUMP,
+                                                           destinationSystemDbId,
+                                                           playerDbId);
   maybeDestinationProcessor->second->pushMessage(std::move(finished));
 }
 

--- a/src/server/lib/consumers/system/DockMessageConsumer.cc
+++ b/src/server/lib/consumers/system/DockMessageConsumer.cc
@@ -76,11 +76,11 @@ void DockMessageConsumer::handleUndocking(const DockMessage &message) const
   auto added = std::make_unique<EntityAddedMessage>(shipDbId, EntityKind::SHIP, systemDbId);
   m_messageQueue->pushMessage(std::move(added));
 
-  auto started = std::make_unique<LoadingStartedMessage>(systemDbId);
+  auto started = std::make_unique<LoadingStartedMessage>(LoadingTransition::UNDOCK, systemDbId);
   started->copyClientIdIfDefined(message);
   m_messageQueue->pushMessage(std::move(started));
 
-  auto finished = std::make_unique<LoadingFinishedMessage>(systemDbId);
+  auto finished = std::make_unique<LoadingFinishedMessage>(LoadingTransition::UNDOCK, systemDbId);
   finished->copyClientIdIfDefined(message);
   m_messageQueue->pushMessage(std::move(finished));
 }

--- a/tests/unit/bsgo/messages/loading/LoadingFinishedMessageTest.cc
+++ b/tests/unit/bsgo/messages/loading/LoadingFinishedMessageTest.cc
@@ -12,6 +12,7 @@ auto assertMessagesAreEqual(const LoadingFinishedMessage &actual,
 {
   EXPECT_EQ(actual.type(), expected.type());
   EXPECT_EQ(actual.tryGetClientId(), expected.tryGetClientId());
+  EXPECT_EQ(actual.getTransition(), expected.getTransition());
   EXPECT_EQ(actual.getSystemDbId(), expected.getSystemDbId());
   EXPECT_EQ(actual.tryGetPlayerDbId(), expected.tryGetPlayerDbId());
 }
@@ -19,9 +20,9 @@ auto assertMessagesAreEqual(const LoadingFinishedMessage &actual,
 
 TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, Basic)
 {
-  const LoadingFinishedMessage expected(Uuid{1234}, Uuid{7845});
+  const LoadingFinishedMessage expected(LoadingTransition::JUMP, Uuid{1234}, Uuid{7845});
 
-  LoadingFinishedMessage actual(Uuid{4});
+  LoadingFinishedMessage actual(LoadingTransition::UNDOCK, Uuid{4});
   actual.setClientId(Uuid{12});
 
   serializeAndDeserializeMessage(expected, actual);
@@ -30,9 +31,9 @@ TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, Basic)
 
 TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, WithoutPlayerDbId)
 {
-  const LoadingFinishedMessage expected(Uuid{32});
+  const LoadingFinishedMessage expected(LoadingTransition::LOGIN, Uuid{32});
 
-  LoadingFinishedMessage actual(Uuid{489}, Uuid{6578});
+  LoadingFinishedMessage actual(LoadingTransition::JUMP, Uuid{489}, Uuid{6578});
 
   serializeAndDeserializeMessage(expected, actual);
   assertMessagesAreEqual(actual, expected);
@@ -40,10 +41,10 @@ TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, WithoutPlayerDbId)
 
 TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, WithClientId)
 {
-  LoadingFinishedMessage expected(Uuid{92}, Uuid{156});
+  LoadingFinishedMessage expected(LoadingTransition::UNDOCK, Uuid{92}, Uuid{156});
   expected.setClientId(Uuid{17});
 
-  LoadingFinishedMessage actual(Uuid{10}, Uuid{7});
+  LoadingFinishedMessage actual(LoadingTransition::LOGIN, Uuid{10}, Uuid{7});
 
   serializeAndDeserializeMessage(expected, actual);
   assertMessagesAreEqual(actual, expected);
@@ -51,7 +52,7 @@ TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, WithClientId)
 
 TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, Clone)
 {
-  const LoadingFinishedMessage expected(Uuid{98}, Uuid{57});
+  const LoadingFinishedMessage expected(LoadingTransition::LOGIN, Uuid{98}, Uuid{57});
   const auto cloned = expected.clone();
 
   ASSERT_EQ(cloned->type(), MessageType::LOADING_FINISHED);
@@ -60,7 +61,7 @@ TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, Clone)
 
 TEST(Unit_Bsgo_Serialization_LoadingFinishedMessage, CloneWithoutPlayerDbId)
 {
-  const LoadingFinishedMessage expected(Uuid{37});
+  const LoadingFinishedMessage expected(LoadingTransition::JUMP, Uuid{37});
   const auto cloned = expected.clone();
 
   ASSERT_EQ(cloned->type(), MessageType::LOADING_FINISHED);

--- a/tests/unit/bsgo/messages/loading/LoadingStartedMessageTest.cc
+++ b/tests/unit/bsgo/messages/loading/LoadingStartedMessageTest.cc
@@ -12,6 +12,7 @@ auto assertMessagesAreEqual(const LoadingStartedMessage &actual,
 {
   EXPECT_EQ(actual.type(), expected.type());
   EXPECT_EQ(actual.tryGetClientId(), expected.tryGetClientId());
+  EXPECT_EQ(actual.getTransition(), expected.getTransition());
   EXPECT_EQ(actual.getSystemDbId(), expected.getSystemDbId());
   EXPECT_EQ(actual.tryGetPlayerDbId(), expected.tryGetPlayerDbId());
 }
@@ -19,9 +20,9 @@ auto assertMessagesAreEqual(const LoadingStartedMessage &actual,
 
 TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, Basic)
 {
-  const LoadingStartedMessage expected(Uuid{1234}, Uuid{7845});
+  const LoadingStartedMessage expected(LoadingTransition::JUMP, Uuid{1234}, Uuid{7845});
 
-  LoadingStartedMessage actual(Uuid{4});
+  LoadingStartedMessage actual(LoadingTransition::UNDOCK, Uuid{4});
   actual.setClientId(Uuid{12});
 
   serializeAndDeserializeMessage(expected, actual);
@@ -30,9 +31,9 @@ TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, Basic)
 
 TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, WithoutPlayerDbId)
 {
-  const LoadingStartedMessage expected(Uuid{32});
+  const LoadingStartedMessage expected(LoadingTransition::LOGIN, Uuid{32});
 
-  LoadingStartedMessage actual(Uuid{489}, Uuid{6578});
+  LoadingStartedMessage actual(LoadingTransition::JUMP, Uuid{489}, Uuid{6578});
 
   serializeAndDeserializeMessage(expected, actual);
   assertMessagesAreEqual(actual, expected);
@@ -40,10 +41,10 @@ TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, WithoutPlayerDbId)
 
 TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, WithClientId)
 {
-  LoadingStartedMessage expected(Uuid{92}, Uuid{156});
+  LoadingStartedMessage expected(LoadingTransition::UNDOCK, Uuid{92}, Uuid{156});
   expected.setClientId(Uuid{17});
 
-  LoadingStartedMessage actual(Uuid{10}, Uuid{7});
+  LoadingStartedMessage actual(LoadingTransition::LOGIN, Uuid{10}, Uuid{7});
 
   serializeAndDeserializeMessage(expected, actual);
   assertMessagesAreEqual(actual, expected);
@@ -51,7 +52,7 @@ TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, WithClientId)
 
 TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, Clone)
 {
-  const LoadingStartedMessage expected(Uuid{98}, Uuid{57});
+  const LoadingStartedMessage expected(LoadingTransition::JUMP, Uuid{98}, Uuid{57});
   const auto cloned = expected.clone();
 
   ASSERT_EQ(cloned->type(), MessageType::LOADING_STARTED);
@@ -60,7 +61,7 @@ TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, Clone)
 
 TEST(Unit_Bsgo_Serialization_LoadingStartedMessage, CloneWithoutPlayerDbId)
 {
-  const LoadingStartedMessage expected(Uuid{37});
+  const LoadingStartedMessage expected(LoadingTransition::LOGIN, Uuid{37});
   const auto cloned = expected.clone();
 
   ASSERT_EQ(cloned->type(), MessageType::LOADING_STARTED);


### PR DESCRIPTION
# Work

## Context

The client application is currently loading most of the data directly from the database. This is not ideal for several reasons, the main one being that in a client/server architecture it would force to expose the database connection to the outside world.

## How to fix it?

Loading the data when a client connects to the server should follow the same logic as for the rest of the data: through messages. In order to do this, we first need to make the server able to produce such messages.

**Note:** the plan is laid out in more details in #9.

## Key changes

### Loading strategy

In #9 we added a single `PlayerListMessage` as a POC of the loading process. The idea is to extend this and add more messages such as `ShipListMessage`, `AsteroidListMessage`, etc. each one carrying one kind of information (more details in #23).

In order to make this fully functional, we need to make sure that the additional messages are produced somehow. The place to do this seems to be the `LoadingMessagesConsumer`: ideally this consumer should receive all loading messages and be able to take an action.

Initially in #9 the login consumer was producing both the `LoadingStarted/FinishedMessage` and the `PlayerListMessage`. Those messages were received in the system processor and populated with the relevant data (see diagram in #12). However this feels a bit artificial. It means that the `LoginMessageConsumer` has knowledge of the data that needs to be loaded upon loading. With the other loading messages, this would mean that for example the `JumpMessageConsumer` is aware of what kind of information are needed to be sent to the client applications when a jump is performed. It might not be that bad, but it seems cleaner to do it another way. 

A better approach is to introduce a `LoadingTransition`: this enumeration defines the reason why a certain loading message is needed. This also makes the loading process more resilient by making sure that the client application can correlate a `LoadingStartedMessage` with a `LoadingFinishedMessage` by verifying that they both have the same transition.

### Verification in the client app

The client application is using the `LoadingStartedMessage` and the `LoadingFinishedMessage` to transition from one screen to the other. In order to guarantee that we receive the data we expect from the server, we can leverage the new loading transition to make sure that the transition defined in the `LoadingFinishedMessage` corresponds to the one defined in `LoadingStartedMessage`.

# Tests

Some unit tests were added to make sure that the de/serialization of the messages is working properly. Additionally the loading transition of the messages was verified in the client application.

# Future work

Currently the loading messages sent in case of the player undocks are not routed to the `LoadingMessagesConsumer`. This is expected (as it was not needed before) but will need to be modified to allow the consumer to interpret **all** loading messages.

