### PR TITLE
feat: Reroute loading messages from undock operation

### DIFF
--- a/src/server/lib/consumers/input/LoginMessageConsumer.cc
+++ b/src/server/lib/consumers/input/LoginMessageConsumer.cc
@@ -8,12 +8,12 @@ namespace bsgo {
 LoginMessageConsumer::LoginMessageConsumer(LoginServicePtr loginService,
                                            ClientManagerShPtr clientManager,
                                            SystemProcessorMap systemProcessors,
-                                           IMessageQueue *const messageQueue)
+                                           IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("login", {MessageType::LOGIN})
   , m_loginService(std::move(loginService))
   , m_systemProcessors(std::move(systemProcessors))
   , m_clientManager(std::move(clientManager))
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_loginService)
   {
@@ -23,7 +23,7 @@ LoginMessageConsumer::LoginMessageConsumer(LoginServicePtr loginService,
   {
     throw std::invalid_argument("Expected non null client manager");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -61,7 +61,7 @@ void LoginMessageConsumer::handleLogin(const LoginMessage &message) const
   out->validate();
   out->copyClientIdIfDefined(message);
 
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
   publishLoadingMessages(clientId, *playerDbId);
 }
 

--- a/src/server/lib/consumers/input/LoginMessageConsumer.hh
+++ b/src/server/lib/consumers/input/LoginMessageConsumer.hh
@@ -16,7 +16,7 @@ class LoginMessageConsumer : public AbstractMessageConsumer
   LoginMessageConsumer(LoginServicePtr loginService,
                        ClientManagerShPtr clientManager,
                        SystemProcessorMap systemProcessors,
-                       IMessageQueue *const messageQueue);
+                       IMessageQueue *const outputMessageQueue);
   ~LoginMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -25,7 +25,7 @@ class LoginMessageConsumer : public AbstractMessageConsumer
   LoginServicePtr m_loginService{};
   SystemProcessorMap m_systemProcessors{};
   ClientManagerShPtr m_clientManager{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleLogin(const LoginMessage &message) const;
   void publishLoadingMessages(const bsgo::Uuid clientId, const bsgo::Uuid playerDbId) const;

--- a/src/server/lib/consumers/input/LogoutMessageConsumer.cc
+++ b/src/server/lib/consumers/input/LogoutMessageConsumer.cc
@@ -7,12 +7,12 @@ namespace bsgo {
 LogoutMessageConsumer::LogoutMessageConsumer(ClientManagerShPtr clientManager,
                                              SystemServiceShPtr systemService,
                                              SystemProcessorMap systemProcessors,
-                                             IMessageQueue *const messageQueue)
+                                             IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("logout", {MessageType::LOGOUT})
   , m_clientManager(std::move(clientManager))
   , m_systemProcessors(std::move(systemProcessors))
   , m_systemService(std::move(systemService))
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_clientManager)
   {
@@ -22,7 +22,7 @@ LogoutMessageConsumer::LogoutMessageConsumer(ClientManagerShPtr clientManager,
   {
     throw std::invalid_argument("Expected non null system service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -84,7 +84,7 @@ void LogoutMessageConsumer::notifyClientAndCloseConnectionIfNeeded(const Uuid pl
   auto out = std::make_unique<LogoutMessage>(playerDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/input/LogoutMessageConsumer.hh
+++ b/src/server/lib/consumers/input/LogoutMessageConsumer.hh
@@ -17,7 +17,7 @@ class LogoutMessageConsumer : public AbstractMessageConsumer
   LogoutMessageConsumer(ClientManagerShPtr clientManager,
                         SystemServiceShPtr systemService,
                         SystemProcessorMap systemProcessors,
-                        IMessageQueue *const messageQueue);
+                        IMessageQueue *const outputMessageQueue);
   ~LogoutMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -26,7 +26,7 @@ class LogoutMessageConsumer : public AbstractMessageConsumer
   ClientManagerShPtr m_clientManager{};
   SystemProcessorMap m_systemProcessors{};
   SystemServiceShPtr m_systemService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleLogout(const LogoutMessage &message) const;
   void notifyClientAndCloseConnectionIfNeeded(const Uuid playerDbId,

--- a/src/server/lib/consumers/input/SignupMessageConsumer.cc
+++ b/src/server/lib/consumers/input/SignupMessageConsumer.cc
@@ -5,11 +5,11 @@ namespace bsgo {
 
 SignupMessageConsumer::SignupMessageConsumer(SignupServicePtr signupService,
                                              ClientManagerShPtr clientManager,
-                                             IMessageQueue *const messageQueue)
+                                             IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("signup", {MessageType::SIGNUP})
   , m_signupService(std::move(signupService))
   , m_clientManager(std::move(clientManager))
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_signupService)
   {
@@ -19,7 +19,7 @@ SignupMessageConsumer::SignupMessageConsumer(SignupServicePtr signupService,
   {
     throw std::invalid_argument("Expected non null client manager");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -60,7 +60,7 @@ void SignupMessageConsumer::handleSignup(const SignupMessage &message) const
                                                                      : std::optional<Uuid>{});
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/input/SignupMessageConsumer.hh
+++ b/src/server/lib/consumers/input/SignupMessageConsumer.hh
@@ -14,7 +14,7 @@ class SignupMessageConsumer : public AbstractMessageConsumer
   public:
   SignupMessageConsumer(SignupServicePtr signupService,
                         ClientManagerShPtr clientManager,
-                        IMessageQueue *const messageQueue);
+                        IMessageQueue *const outputMessageQueue);
   ~SignupMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -22,7 +22,7 @@ class SignupMessageConsumer : public AbstractMessageConsumer
   private:
   SignupServicePtr m_signupService{};
   ClientManagerShPtr m_clientManager{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleSignup(const SignupMessage &message) const;
 };

--- a/src/server/lib/consumers/internal/ComponentSyncMessageConsumer.cc
+++ b/src/server/lib/consumers/internal/ComponentSyncMessageConsumer.cc
@@ -6,15 +6,15 @@ namespace bsgo {
 
 ComponentSyncMessageConsumer::ComponentSyncMessageConsumer(SystemServiceShPtr systemService,
                                                            SystemProcessorMap systemProcessors,
-                                                           IMessageQueue *const messageQueue)
+                                                           IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("component", {MessageType::COMPONENT_SYNC})
   , m_systemService(std::move(systemService))
   , m_systemProcessors(std::move(systemProcessors))
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   addModule("sync");
 
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -53,7 +53,7 @@ void ComponentSyncMessageConsumer::onMessageReceived(const IMessage &message)
 
   auto out = message.clone();
   out->as<ComponentSyncMessage>().setSystemDbId(*systemDbId);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 auto ComponentSyncMessageConsumer::determineSystemForShip(const Uuid shipDbId) const -> Uuid

--- a/src/server/lib/consumers/internal/ComponentSyncMessageConsumer.hh
+++ b/src/server/lib/consumers/internal/ComponentSyncMessageConsumer.hh
@@ -15,7 +15,7 @@ class ComponentSyncMessageConsumer : public AbstractMessageConsumer
   public:
   ComponentSyncMessageConsumer(SystemServiceShPtr systemService,
                                SystemProcessorMap systemProcessors,
-                               IMessageQueue *const messageQueue);
+                               IMessageQueue *const outputMessageQueue);
   ~ComponentSyncMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -23,7 +23,7 @@ class ComponentSyncMessageConsumer : public AbstractMessageConsumer
   private:
   SystemServiceShPtr m_systemService{};
   SystemProcessorMap m_systemProcessors{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   auto determineSystemForShip(const Uuid shipDbId) const -> Uuid;
   auto determineSystemForAsteroid(const Uuid asteroidDbId) const -> Uuid;

--- a/src/server/lib/consumers/internal/EntityRemovedMessageConsumer.cc
+++ b/src/server/lib/consumers/internal/EntityRemovedMessageConsumer.cc
@@ -7,11 +7,11 @@ namespace bsgo {
 
 EntityRemovedMessageConsumer::EntityRemovedMessageConsumer(SystemServiceShPtr systemService,
                                                            SystemProcessorMap systemProcessors,
-                                                           IMessageQueue *const messageQueue)
+                                                           IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("entity", {MessageType::ENTITY_REMOVED})
   , m_systemService(std::move(systemService))
   , m_systemProcessors(std::move(systemProcessors))
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   addModule("removed");
 
@@ -19,7 +19,7 @@ EntityRemovedMessageConsumer::EntityRemovedMessageConsumer(SystemServiceShPtr sy
   {
     throw std::invalid_argument("Expected non null system service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }

--- a/src/server/lib/consumers/internal/EntityRemovedMessageConsumer.hh
+++ b/src/server/lib/consumers/internal/EntityRemovedMessageConsumer.hh
@@ -14,7 +14,7 @@ class EntityRemovedMessageConsumer : public AbstractMessageConsumer
   public:
   EntityRemovedMessageConsumer(SystemServiceShPtr systemService,
                                SystemProcessorMap systemProcessors,
-                               IMessageQueue *const messageQueue);
+                               IMessageQueue *const outputMessageQueue);
   ~EntityRemovedMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -22,7 +22,7 @@ class EntityRemovedMessageConsumer : public AbstractMessageConsumer
   private:
   SystemServiceShPtr m_systemService{};
   SystemProcessorMap m_systemProcessors{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleShipEntityRemoved(const Uuid shipDbId, const bool dead) const;
   void handleAsteroidEntityRemoved(const Uuid asteroidDbId, const bool dead) const;

--- a/src/server/lib/consumers/internal/JumpMessageConsumer.cc
+++ b/src/server/lib/consumers/internal/JumpMessageConsumer.cc
@@ -11,12 +11,12 @@ namespace bsgo {
 JumpMessageConsumer::JumpMessageConsumer(SystemServiceShPtr systemService,
                                          ClientManagerShPtr clientManager,
                                          SystemProcessorMap systemProcessors,
-                                         IMessageQueue *const messageQueue)
+                                         IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("jump", {MessageType::JUMP})
   , m_systemService(std::move(systemService))
   , m_clientManager(std::move(clientManager))
   , m_systemProcessors(std::move(systemProcessors))
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_systemService)
   {
@@ -26,7 +26,7 @@ JumpMessageConsumer::JumpMessageConsumer(SystemServiceShPtr systemService,
   {
     throw std::invalid_argument("Expected non null client manager");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -55,7 +55,7 @@ void JumpMessageConsumer::onMessageReceived(const IMessage &message)
                                            res.sourceSystem,
                                            res.destinationSystem);
   out->copyClientIdIfDefined(jump);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 void JumpMessageConsumer::handlePostJumpSystemMessages(const Uuid shipDbId,

--- a/src/server/lib/consumers/internal/JumpMessageConsumer.hh
+++ b/src/server/lib/consumers/internal/JumpMessageConsumer.hh
@@ -15,7 +15,7 @@ class JumpMessageConsumer : public AbstractMessageConsumer
   JumpMessageConsumer(SystemServiceShPtr systemService,
                       ClientManagerShPtr clientManager,
                       SystemProcessorMap systemProcessors,
-                      IMessageQueue *const messageQueue);
+                      IMessageQueue *const outputMessageQueue);
   ~JumpMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -24,7 +24,7 @@ class JumpMessageConsumer : public AbstractMessageConsumer
   SystemServiceShPtr m_systemService{};
   ClientManagerShPtr m_clientManager{};
   SystemProcessorMap m_systemProcessors{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handlePostJumpSystemMessages(const Uuid shipDbId,
                                     const Uuid sourceSystemDbId,

--- a/src/server/lib/consumers/internal/LootMessageConsumer.cc
+++ b/src/server/lib/consumers/internal/LootMessageConsumer.cc
@@ -5,16 +5,16 @@
 namespace bsgo {
 
 LootMessageConsumer::LootMessageConsumer(SystemServiceShPtr systemService,
-                                         IMessageQueue *const messageQueue)
+                                         IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("loot", {MessageType::LOOT})
   , m_systemService(std::move(systemService))
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_systemService)
   {
     throw std::invalid_argument("Expected non null system service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -36,7 +36,7 @@ void LootMessageConsumer::onMessageReceived(const IMessage &message)
 
   auto out = std::make_unique<LootMessage>(playerDbId, resourceDbId, amount);
   out->copyClientIdIfDefined(loot);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/internal/LootMessageConsumer.hh
+++ b/src/server/lib/consumers/internal/LootMessageConsumer.hh
@@ -10,14 +10,14 @@ namespace bsgo {
 class LootMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  LootMessageConsumer(SystemServiceShPtr systemService, IMessageQueue *const messageQueue);
+  LootMessageConsumer(SystemServiceShPtr systemService, IMessageQueue *const outputMessageQueue);
   ~LootMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   SystemServiceShPtr m_systemService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 };
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/DockMessageConsumer.cc
+++ b/src/server/lib/consumers/system/DockMessageConsumer.cc
@@ -6,10 +6,13 @@
 
 namespace bsgo {
 
-DockMessageConsumer::DockMessageConsumer(const Services &services, IMessageQueue *const messageQueue)
+DockMessageConsumer::DockMessageConsumer(const Services &services,
+                                         IMessageQueue *const systemMessageQueue,
+                                         IMessageQueue *const messageQueue)
   : AbstractMessageConsumer("dock", {MessageType::DOCK})
   , m_shipService(services.ship)
   , m_entityService(services.entity)
+  , m_systemMessageQueue(systemMessageQueue)
   , m_messageQueue(messageQueue)
 {
   if (nullptr == m_shipService)
@@ -19,6 +22,10 @@ DockMessageConsumer::DockMessageConsumer(const Services &services, IMessageQueue
   if (nullptr == m_entityService)
   {
     throw std::invalid_argument("Expected non null entity service");
+  }
+  if (nullptr == m_systemMessageQueue)
+  {
+    throw std::invalid_argument("Expected non null system message queue");
   }
   if (nullptr == m_messageQueue)
   {
@@ -78,11 +85,11 @@ void DockMessageConsumer::handleUndocking(const DockMessage &message) const
 
   auto started = std::make_unique<LoadingStartedMessage>(LoadingTransition::UNDOCK, systemDbId);
   started->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(started));
+  m_systemMessageQueue->pushMessage(std::move(started));
 
   auto finished = std::make_unique<LoadingFinishedMessage>(LoadingTransition::UNDOCK, systemDbId);
   finished->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(finished));
+  m_systemMessageQueue->pushMessage(std::move(finished));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/DockMessageConsumer.cc
+++ b/src/server/lib/consumers/system/DockMessageConsumer.cc
@@ -8,12 +8,12 @@ namespace bsgo {
 
 DockMessageConsumer::DockMessageConsumer(const Services &services,
                                          IMessageQueue *const systemMessageQueue,
-                                         IMessageQueue *const messageQueue)
+                                         IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("dock", {MessageType::DOCK})
   , m_shipService(services.ship)
   , m_entityService(services.entity)
   , m_systemMessageQueue(systemMessageQueue)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_shipService)
   {
@@ -27,7 +27,7 @@ DockMessageConsumer::DockMessageConsumer(const Services &services,
   {
     throw std::invalid_argument("Expected non null system message queue");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -61,7 +61,7 @@ void DockMessageConsumer::handleDocking(const DockMessage &message) const
   auto out = std::make_unique<DockMessage>(shipDbId, true, systemDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 void DockMessageConsumer::handleUndocking(const DockMessage &message) const
@@ -78,10 +78,10 @@ void DockMessageConsumer::handleUndocking(const DockMessage &message) const
   auto out = std::make_unique<DockMessage>(shipDbId, false, systemDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 
   auto added = std::make_unique<EntityAddedMessage>(shipDbId, EntityKind::SHIP, systemDbId);
-  m_messageQueue->pushMessage(std::move(added));
+  m_outputMessageQueue->pushMessage(std::move(added));
 
   auto started = std::make_unique<LoadingStartedMessage>(LoadingTransition::UNDOCK, systemDbId);
   started->copyClientIdIfDefined(message);

--- a/src/server/lib/consumers/system/DockMessageConsumer.hh
+++ b/src/server/lib/consumers/system/DockMessageConsumer.hh
@@ -13,7 +13,7 @@ class DockMessageConsumer : public AbstractMessageConsumer
   public:
   DockMessageConsumer(const Services &services,
                       IMessageQueue *const systemMessageQueue,
-                      IMessageQueue *const messageQueue);
+                      IMessageQueue *const outputMessageQueue);
   ~DockMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -22,7 +22,7 @@ class DockMessageConsumer : public AbstractMessageConsumer
   ShipServiceShPtr m_shipService{};
   EntityServiceShPtr m_entityService{};
   IMessageQueue *const m_systemMessageQueue{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleDocking(const DockMessage &message) const;
   void handleUndocking(const DockMessage &message) const;

--- a/src/server/lib/consumers/system/DockMessageConsumer.hh
+++ b/src/server/lib/consumers/system/DockMessageConsumer.hh
@@ -11,7 +11,9 @@ namespace bsgo {
 class DockMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  DockMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  DockMessageConsumer(const Services &services,
+                      IMessageQueue *const systemMessageQueue,
+                      IMessageQueue *const messageQueue);
   ~DockMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
@@ -19,6 +21,7 @@ class DockMessageConsumer : public AbstractMessageConsumer
   private:
   ShipServiceShPtr m_shipService{};
   EntityServiceShPtr m_entityService{};
+  IMessageQueue *const m_systemMessageQueue{};
   IMessageQueue *const m_messageQueue{};
 
   void handleDocking(const DockMessage &message) const;

--- a/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
+++ b/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
@@ -5,10 +5,10 @@
 namespace bsgo {
 
 EntityAddedMessageConsumer::EntityAddedMessageConsumer(const Services &services,
-                                                       IMessageQueue *const messageQueue)
+                                                       IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("entity", {MessageType::ENTITY_ADDED})
   , m_entityService(services.entity)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   addModule("added");
 
@@ -16,7 +16,7 @@ EntityAddedMessageConsumer::EntityAddedMessageConsumer(const Services &services,
   {
     throw std::invalid_argument("Expected non null entity service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -49,7 +49,7 @@ void EntityAddedMessageConsumer::handleShipAdded(const Uuid shipDbId, const Uuid
   }
 
   auto out = std::make_unique<EntityAddedMessage>(shipDbId, EntityKind::SHIP, systemDbId);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/EntityAddedMessageConsumer.hh
+++ b/src/server/lib/consumers/system/EntityAddedMessageConsumer.hh
@@ -10,14 +10,14 @@ namespace bsgo {
 class EntityAddedMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  EntityAddedMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  EntityAddedMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~EntityAddedMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   EntityServiceShPtr m_entityService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleShipAdded(const Uuid shipDbId, const Uuid systemDbId) const;
 };

--- a/src/server/lib/consumers/system/EntityDeletedMessageConsumer.cc
+++ b/src/server/lib/consumers/system/EntityDeletedMessageConsumer.cc
@@ -5,10 +5,10 @@
 namespace bsgo {
 
 EntityDeletedMessageConsumer::EntityDeletedMessageConsumer(const Services &services,
-                                                           IMessageQueue *const messageQueue)
+                                                           IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("entity", {MessageType::ENTITY_REMOVED})
   , m_entityService(services.entity)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   addModule("removed");
 
@@ -16,7 +16,7 @@ EntityDeletedMessageConsumer::EntityDeletedMessageConsumer(const Services &servi
   {
     throw std::invalid_argument("Expected non null entity service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -46,7 +46,7 @@ void EntityDeletedMessageConsumer::onMessageReceived(const IMessage &message)
                                                     entityKind,
                                                     removed.isDead(),
                                                     systemDbId);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 void EntityDeletedMessageConsumer::handleShipRemoved(const Uuid shipDbId) const

--- a/src/server/lib/consumers/system/EntityDeletedMessageConsumer.hh
+++ b/src/server/lib/consumers/system/EntityDeletedMessageConsumer.hh
@@ -10,14 +10,14 @@ namespace bsgo {
 class EntityDeletedMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  EntityDeletedMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  EntityDeletedMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~EntityDeletedMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   EntityServiceShPtr m_entityService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleShipRemoved(const Uuid shipDbId) const;
   void handleAsteroidRemoved(const Uuid asteroidDbId) const;

--- a/src/server/lib/consumers/system/EquipMessageConsumer.cc
+++ b/src/server/lib/consumers/system/EquipMessageConsumer.cc
@@ -4,16 +4,16 @@
 namespace bsgo {
 
 EquipMessageConsumer::EquipMessageConsumer(const Services &services,
-                                           IMessageQueue *const messageQueue)
+                                           IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("equip", {MessageType::EQUIP})
   , m_lockerService(services.locker)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_lockerService)
   {
     throw std::invalid_argument("Expected non null locker service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -58,7 +58,7 @@ void EquipMessageConsumer::handleEquipRequest(const EquipMessage &message) const
   auto out = std::make_unique<EquipMessage>(EquipType::EQUIP, shipDbId, type, itemDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 void EquipMessageConsumer::handleUnequipRequest(const EquipMessage &message) const
@@ -78,7 +78,7 @@ void EquipMessageConsumer::handleUnequipRequest(const EquipMessage &message) con
   auto out = std::make_unique<EquipMessage>(EquipType::UNEQUIP, shipDbId, type, itemDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/EquipMessageConsumer.hh
+++ b/src/server/lib/consumers/system/EquipMessageConsumer.hh
@@ -12,14 +12,14 @@ namespace bsgo {
 class EquipMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  EquipMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  EquipMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~EquipMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   LockerServiceShPtr m_lockerService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleEquipRequest(const EquipMessage &message) const;
   void handleUnequipRequest(const EquipMessage &message) const;

--- a/src/server/lib/consumers/system/HangarMessageConsumer.cc
+++ b/src/server/lib/consumers/system/HangarMessageConsumer.cc
@@ -4,16 +4,16 @@
 namespace bsgo {
 
 HangarMessageConsumer::HangarMessageConsumer(const Services &services,
-                                             IMessageQueue *const messageQueue)
+                                             IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("hangar", {MessageType::HANGAR})
   , m_shipService(services.ship)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_shipService)
   {
     throw std::invalid_argument("Expected non null ship service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -42,7 +42,7 @@ void HangarMessageConsumer::handleShipSwitchRequest(const HangarMessage &message
   auto out = std::make_unique<HangarMessage>(shipDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/HangarMessageConsumer.hh
+++ b/src/server/lib/consumers/system/HangarMessageConsumer.hh
@@ -11,14 +11,14 @@ namespace bsgo {
 class HangarMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  HangarMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  HangarMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~HangarMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   ShipServiceShPtr m_shipService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleShipSwitchRequest(const HangarMessage &message) const;
 };

--- a/src/server/lib/consumers/system/JumpCancelledMessageConsumer.cc
+++ b/src/server/lib/consumers/system/JumpCancelledMessageConsumer.cc
@@ -4,16 +4,16 @@
 namespace bsgo {
 
 JumpCancelledMessageConsumer::JumpCancelledMessageConsumer(const Services &services,
-                                                           IMessageQueue *const messageQueue)
+                                                           IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("jump_cancelled", {MessageType::JUMP_CANCELLED})
   , m_jumpService(services.jump)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_jumpService)
   {
     throw std::invalid_argument("Expected non null jump service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -42,7 +42,7 @@ void JumpCancelledMessageConsumer::handleJumpCancellation(const JumpCancelledMes
   auto out = std::make_unique<JumpCancelledMessage>(shipDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/JumpCancelledMessageConsumer.hh
+++ b/src/server/lib/consumers/system/JumpCancelledMessageConsumer.hh
@@ -11,14 +11,14 @@ namespace bsgo {
 class JumpCancelledMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  JumpCancelledMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  JumpCancelledMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~JumpCancelledMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   JumpServiceShPtr m_jumpService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleJumpCancellation(const JumpCancelledMessage &message) const;
 };

--- a/src/server/lib/consumers/system/JumpRequestedMessageConsumer.cc
+++ b/src/server/lib/consumers/system/JumpRequestedMessageConsumer.cc
@@ -4,16 +4,16 @@
 namespace bsgo {
 
 JumpRequestedMessageConsumer::JumpRequestedMessageConsumer(const Services &services,
-                                                           IMessageQueue *const messageQueue)
+                                                           IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("jump_Requested", {MessageType::JUMP_REQUESTED})
   , m_jumpService(services.jump)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_jumpService)
   {
     throw std::invalid_argument("Expected non null jump service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -43,7 +43,7 @@ void JumpRequestedMessageConsumer::handleJumpRequest(const JumpRequestedMessage 
   auto out = std::make_unique<JumpRequestedMessage>(shipDbId, jumpSystem);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/JumpRequestedMessageConsumer.hh
+++ b/src/server/lib/consumers/system/JumpRequestedMessageConsumer.hh
@@ -11,14 +11,14 @@ namespace bsgo {
 class JumpRequestedMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  JumpRequestedMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  JumpRequestedMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~JumpRequestedMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   JumpServiceShPtr m_jumpService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleJumpRequest(const JumpRequestedMessage &message) const;
 };

--- a/src/server/lib/consumers/system/LoadingMessagesConsumer.cc
+++ b/src/server/lib/consumers/system/LoadingMessagesConsumer.cc
@@ -5,11 +5,11 @@
 namespace bsgo {
 
 LoadingMessagesConsumer::LoadingMessagesConsumer(const Services & /*services*/,
-                                                 IMessageQueue *const messageQueue)
+                                                 IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("loading", {MessageType::LOADING_FINISHED, MessageType::LOADING_STARTED})
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -33,13 +33,13 @@ void LoadingMessagesConsumer::onMessageReceived(const IMessage &message)
 
 void LoadingMessagesConsumer::forwardLoadingStartedMessage(const LoadingStartedMessage &message) const
 {
-  m_messageQueue->pushMessage(message.clone());
+  m_outputMessageQueue->pushMessage(message.clone());
 }
 
 void LoadingMessagesConsumer::forwardLoadingFinishedMessage(
   const LoadingFinishedMessage &message) const
 {
-  m_messageQueue->pushMessage(message.clone());
+  m_outputMessageQueue->pushMessage(message.clone());
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/LoadingMessagesConsumer.hh
+++ b/src/server/lib/consumers/system/LoadingMessagesConsumer.hh
@@ -13,13 +13,13 @@ namespace bsgo {
 class LoadingMessagesConsumer : public AbstractMessageConsumer
 {
   public:
-  LoadingMessagesConsumer(const Services &services, IMessageQueue *const messageQueue);
+  LoadingMessagesConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~LoadingMessagesConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void forwardLoadingStartedMessage(const LoadingStartedMessage &message) const;
   void forwardLoadingFinishedMessage(const LoadingFinishedMessage &message) const;

--- a/src/server/lib/consumers/system/PurchaseMessageConsumer.cc
+++ b/src/server/lib/consumers/system/PurchaseMessageConsumer.cc
@@ -4,16 +4,16 @@
 namespace bsgo {
 
 PurchaseMessageConsumer::PurchaseMessageConsumer(const Services &services,
-                                                 IMessageQueue *const messageQueue)
+                                                 IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("purchase", {MessageType::PURCHASE})
   , m_purchaseService(services.purchase)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_purchaseService)
   {
     throw std::invalid_argument("Expected non null purchase service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -60,7 +60,7 @@ void PurchaseMessageConsumer::handleComputerPurchase(const PurchaseMessage &mess
   auto out = std::make_unique<PurchaseMessage>(playerDbId, Item::COMPUTER, computerDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 void PurchaseMessageConsumer::handleShipPurchase(const PurchaseMessage &message) const
@@ -78,7 +78,7 @@ void PurchaseMessageConsumer::handleShipPurchase(const PurchaseMessage &message)
   auto out = std::make_unique<PurchaseMessage>(playerDbId, Item::SHIP, shipDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 void PurchaseMessageConsumer::handleWeaponPurchase(const PurchaseMessage &message) const
@@ -96,7 +96,7 @@ void PurchaseMessageConsumer::handleWeaponPurchase(const PurchaseMessage &messag
   auto out = std::make_unique<PurchaseMessage>(playerDbId, Item::WEAPON, weaponDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/PurchaseMessageConsumer.hh
+++ b/src/server/lib/consumers/system/PurchaseMessageConsumer.hh
@@ -11,14 +11,14 @@ namespace bsgo {
 class PurchaseMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  PurchaseMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  PurchaseMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~PurchaseMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   PurchaseServiceShPtr m_purchaseService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleComputerPurchase(const PurchaseMessage &message) const;
   void handleShipPurchase(const PurchaseMessage &message) const;

--- a/src/server/lib/consumers/system/SlotMessageConsumer.cc
+++ b/src/server/lib/consumers/system/SlotMessageConsumer.cc
@@ -4,16 +4,17 @@
 
 namespace bsgo {
 
-SlotMessageConsumer::SlotMessageConsumer(const Services &services, IMessageQueue *const messageQueue)
+SlotMessageConsumer::SlotMessageConsumer(const Services &services,
+                                         IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("slot", {MessageType::SLOT})
   , m_slotService(services.slot)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_slotService)
   {
     throw std::invalid_argument("Expected non null slot service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -47,7 +48,7 @@ void SlotMessageConsumer::handleWeapon(const SlotMessage &message) const
 
   auto out = std::make_unique<WeaponComponentMessage>(shipDbId, weaponDbId, res.active);
   out->copyClientIdIfDefined(message);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 void SlotMessageConsumer::handleComputer(const SlotMessage &message) const

--- a/src/server/lib/consumers/system/SlotMessageConsumer.hh
+++ b/src/server/lib/consumers/system/SlotMessageConsumer.hh
@@ -10,14 +10,14 @@ namespace bsgo {
 class SlotMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  SlotMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  SlotMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~SlotMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   SlotServiceShPtr m_slotService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 
   void handleWeapon(const SlotMessage &message) const;
   void handleComputer(const SlotMessage &message) const;

--- a/src/server/lib/consumers/system/TargetMessageConsumer.cc
+++ b/src/server/lib/consumers/system/TargetMessageConsumer.cc
@@ -5,16 +5,16 @@
 namespace bsgo {
 
 TargetMessageConsumer::TargetMessageConsumer(const Services &services,
-                                             IMessageQueue *const messageQueue)
+                                             IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("target", {MessageType::TARGET})
   , m_shipService(services.ship)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_shipService)
   {
     throw std::invalid_argument("Expected non null ship service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -40,7 +40,7 @@ void TargetMessageConsumer::onMessageReceived(const IMessage &message)
   auto out = std::make_unique<TargetMessage>(shipDbId, position, res.targetKind, res.targetDbId);
   out->validate();
   out->copyClientIdIfDefined(target);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/TargetMessageConsumer.hh
+++ b/src/server/lib/consumers/system/TargetMessageConsumer.hh
@@ -10,14 +10,14 @@ namespace bsgo {
 class TargetMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  TargetMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  TargetMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~TargetMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   ShipServiceShPtr m_shipService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 };
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/VelocityMessageConsumer.cc
+++ b/src/server/lib/consumers/system/VelocityMessageConsumer.cc
@@ -5,16 +5,16 @@
 namespace bsgo {
 
 VelocityMessageConsumer::VelocityMessageConsumer(const Services &services,
-                                                 IMessageQueue *const messageQueue)
+                                                 IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("velocity", {MessageType::VELOCITY})
   , m_shipService(services.ship)
-  , m_messageQueue(messageQueue)
+  , m_outputMessageQueue(outputMessageQueue)
 {
   if (nullptr == m_shipService)
   {
     throw std::invalid_argument("Expected non null ship service");
   }
-  if (nullptr == m_messageQueue)
+  if (nullptr == m_outputMessageQueue)
   {
     throw std::invalid_argument("Expected non null message queue");
   }
@@ -36,7 +36,7 @@ void VelocityMessageConsumer::onMessageReceived(const IMessage &message)
   auto out = std::make_unique<VelocityMessage>(shipDbId, acceleration);
   out->validate();
   out->copyClientIdIfDefined(velocity);
-  m_messageQueue->pushMessage(std::move(out));
+  m_outputMessageQueue->pushMessage(std::move(out));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/VelocityMessageConsumer.hh
+++ b/src/server/lib/consumers/system/VelocityMessageConsumer.hh
@@ -10,14 +10,14 @@ namespace bsgo {
 class VelocityMessageConsumer : public AbstractMessageConsumer
 {
   public:
-  VelocityMessageConsumer(const Services &services, IMessageQueue *const messageQueue);
+  VelocityMessageConsumer(const Services &services, IMessageQueue *const outputMessageQueue);
   ~VelocityMessageConsumer() override = default;
 
   void onMessageReceived(const IMessage &message) override;
 
   private:
   ShipServiceShPtr m_shipService{};
-  IMessageQueue *const m_messageQueue{};
+  IMessageQueue *const m_outputMessageQueue{};
 };
 
 } // namespace bsgo

--- a/src/server/lib/game/MessageConsumerSetup.cc
+++ b/src/server/lib/game/MessageConsumerSetup.cc
@@ -16,44 +16,44 @@
 
 namespace bsgo {
 
-void createMessageConsumers(IMessageQueue &inputMessagesQueue,
+void createMessageConsumers(IMessageQueue *const inputMessagesQueue,
                             IMessageQueue *const outputMessagesQueue,
                             const Services &services)
 {
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<HangarMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<PurchaseMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<EquipMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
-    std::make_unique<DockMessageConsumer>(services, outputMessagesQueue));
+  inputMessagesQueue->addListener(
+    std::make_unique<DockMessageConsumer>(services, inputMessagesQueue, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<SlotMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<VelocityMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<TargetMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<JumpCancelledMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<JumpRequestedMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<EntityDeletedMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<EntityAddedMessageConsumer>(services, outputMessagesQueue));
 
-  inputMessagesQueue.addListener(
+  inputMessagesQueue->addListener(
     std::make_unique<LoadingMessagesConsumer>(services, outputMessagesQueue));
 }
 

--- a/src/server/lib/game/MessageConsumerSetup.hh
+++ b/src/server/lib/game/MessageConsumerSetup.hh
@@ -7,7 +7,7 @@
 
 namespace bsgo {
 
-void createMessageConsumers(IMessageQueue &inputMessagesQueue,
+void createMessageConsumers(IMessageQueue *const inputMessagesQueue,
                             IMessageQueue *const outputMessagesQueue,
                             const Services &services);
 

--- a/src/server/lib/game/SystemProcessor.cc
+++ b/src/server/lib/game/SystemProcessor.cc
@@ -50,7 +50,7 @@ void SystemProcessor::connectToQueues(IMessageQueue *const internalMessageQueue,
   // with that type and populate the list of players with the ones from the system
   // This service would already have access to the broadcast queue so we can then send
   // this message to the client.
-  createMessageConsumers(*m_inputMessagesQueue, outputMessageQueue, m_services);
+  createMessageConsumers(m_inputMessagesQueue.get(), outputMessageQueue, m_services);
 }
 
 void SystemProcessor::start()


### PR DESCRIPTION
# Work

## Context

The client application is currently loading most of the data directly from the database. This is not ideal for several reasons, the main one being that in a client/server architecture it would force to expose the database connection to the outside world.

## How to fix it?

Loading the data when a client connects to the server should follow the same logic as for the rest of the data: through messages. In order to do this, we first need to make the server able to produce such messages.

**Note:** the plan is laid out in more details in #9.

## Key changes

In #23 we want to allow the server to react to `LoadingStartedMessage` and `LoadingFinishedMessage` internally to add data loading messages and send them to the client applications. This should happen in three situations:
* the user logs into the game
* the user leaves the outpost
* the user jumps to another system

In all three cases, the consumers responsible for processing the related messages already send loading messages: this was done in #12 and #19. Additionally, they also fill in the loading messages with the right transition: this was done in #24.

One step is missing though: not all scenarii lead to the loading messages being processed by the `LoadingMessagesConsumer`. This is due to the structure of the messaging architecture in the server. Each case is described a bit further below.

### The login case

In the login case, the following process already takes place:
* the client app sends a `LoginMessage`
* the LoginMessageConsumer` receives it and verifies the data
* if it succeeds, the consumer sends the `LoadingStartedMessage` and the `LoadingFinishedMessage` to the system the user is logging in
* the system processor receives the message in the `LoadingMessagesConsumer` (see #12)
* the messages are forwarded to the client

It is easy to interpret the loading transition there and produce the right kind of loading messages (corresponding to the shop's data, the locker, etc.).

### The jump case

In the jump case, the following process already takes place:
* the client app sends a `JumpRequestedMessage`
* the `JumpRequestedMessageConsumer` receives it and verifies the data
* if it succeeds, the status of the ship is set to jumping and a timer starts
* when the timer reaches 0, the `StatusSystem` pushes a `JumpMessage` to the internal queue
* the `JumpMessageConsumer` receives the message and update the database
* a new `JumpMessage` is sent to the client app
* also the loading messages are sent to the destination system
* the system processor receives the message in the `LoadingMessagesConsumer` (see #12)

It is easy to interpret the loading transition there and produce the right kind of loading messages (corresponding to the shop's data, the locker, etc.). This is very similar to the login case.

### The undock case

In the undock case, the following process already takes place:
* the client app sends a `DockMessage`
* the `DockMessageConsumer` receives it and verifies it (system consumer)
* if it succeeds, the validated message is sent back to the client
* the loading messages are also produced

In this case there's no way for the `LoadingMessagesConsumer` to receive the loading messages as they are directly sent to the client application. In order to fix this, we need to make the `DockMessageConsumer` aware of the system queue and allow it to push the loading messages to it so that the `LoadingMessagesConsumer` gets the chance to process them.

### The dock case

In the dock case, the following process already takes place:
* the client app sends a `DockeMessage`
* the `DockMessageConsumer` receives it and verifies it (system consumer)
* the consumer uses the `ShipService` to mark the ship as docked
* the `RemovalSystem` generates an `EntityRemovedMessage`
* the `EntityRemovedMessageConsumer` sets the dock status in the database (internal consumer)
* a new `EntityRemovedMessage` is sent to the processor
* the `EntityDeletedMessageConsumer` removes the entity from the system (system consumer)
* and sends the message to the client application

Currently we don't perform any loading when docking: this is because we assume that the content was already loaded upon login.

In case this changes in the future we can use the same approach as for the undock message: on top of sending the `EntityRemovedMessage` the `DockMessageConsumer` can also send a message to the system processor.

# Tests

We verified locally that we still receive the loading messages with the new changes.

# Future work

With this PR merged, we can continue with #23. Additionally, it might make sense to revisit whether we need a loading transition for docking as well: this might make sense to get fresh data for the shop and locker when rejoining the outpost.
