### PR TITLE
feat: Externalized game session logic to a dedicated class

### DIFF
--- a/src/bsgo/messages/MessageParser.cc
+++ b/src/bsgo/messages/MessageParser.cc
@@ -21,6 +21,7 @@
 #include "LootMessage.hh"
 #include "OutpostListMessage.hh"
 #include "PlayerListMessage.hh"
+#include "PlayerLoginDataMessage.hh"
 #include "PurchaseMessage.hh"
 #include "ScannedMessage.hh"
 #include "ShipListMessage.hh"
@@ -139,6 +140,8 @@ auto MessageParser::tryReadMessage(const MessageType &type, std::istream &in)
       return readMessage<OutpostListMessage>(in);
     case MessageType::PLAYER_LIST:
       return readMessage<PlayerListMessage>(in);
+    case MessageType::PLAYER_LOGIN_DATA:
+      return readMessage<PlayerLoginDataMessage>(in);
     case MessageType::PURCHASE:
       return readMessage<PurchaseMessage>(in);
     case MessageType::SCANNED:

--- a/src/bsgo/messages/MessageType.cc
+++ b/src/bsgo/messages/MessageType.cc
@@ -43,6 +43,8 @@ auto str(const MessageType &type) -> std::string
       return "outpost_list";
     case MessageType::PLAYER_LIST:
       return "player_list";
+    case MessageType::PLAYER_LOGIN_DATA:
+      return "player_login_data";
     case MessageType::PURCHASE:
       return "purchase";
     case MessageType::SCANNED:
@@ -66,7 +68,7 @@ auto str(const MessageType &type) -> std::string
   }
 }
 
-auto allMessageTypes() -> std::array<MessageType, 27>
+auto allMessageTypes() -> std::array<MessageType, 28>
 {
   return {MessageType::ASTEROID_LIST,
           MessageType::COMPONENT_SYNC,
@@ -86,6 +88,7 @@ auto allMessageTypes() -> std::array<MessageType, 27>
           MessageType::LOGOUT,
           MessageType::OUTPOST_LIST,
           MessageType::PLAYER_LIST,
+          MessageType::PLAYER_LOGIN_DATA,
           MessageType::PURCHASE,
           MessageType::SCANNED,
           MessageType::SHIP_LIST,

--- a/src/bsgo/messages/MessageType.hh
+++ b/src/bsgo/messages/MessageType.hh
@@ -27,6 +27,7 @@ enum class MessageType
   LOOT,
   OUTPOST_LIST,
   PLAYER_LIST,
+  PLAYER_LOGIN_DATA,
   PURCHASE,
   SCANNED,
   SHIP_LIST,
@@ -39,7 +40,7 @@ enum class MessageType
 };
 
 auto str(const MessageType &type) -> std::string;
-auto allMessageTypes() -> std::array<MessageType, 27>;
+auto allMessageTypes() -> std::array<MessageType, 28>;
 
 auto allMessageTypesAsSet() -> std::unordered_set<MessageType>;
 

--- a/src/bsgo/messages/loading/CMakeLists.txt
+++ b/src/bsgo/messages/loading/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources (bsgo_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/OutpostData.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/OutpostListMessage.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/PlayerListMessage.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/PlayerLoginDataMessage.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/ShipData.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/ShipListMessage.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/WeaponData.cc

--- a/src/bsgo/messages/loading/PlayerLoginDataMessage.cc
+++ b/src/bsgo/messages/loading/PlayerLoginDataMessage.cc
@@ -1,0 +1,68 @@
+
+#include "PlayerLoginDataMessage.hh"
+#include "SerializationUtils.hh"
+
+namespace bsgo {
+
+PlayerLoginDataMessage::PlayerLoginDataMessage()
+  : NetworkMessage(MessageType::PLAYER_LOGIN_DATA)
+{}
+
+PlayerLoginDataMessage::PlayerLoginDataMessage(const Faction faction,
+                                               const Uuid activeShipDbId,
+                                               const bool docked)
+  : NetworkMessage(MessageType::PLAYER_LOGIN_DATA)
+  , m_faction(faction)
+  , m_activeShipDbId(activeShipDbId)
+  , m_docked(docked)
+{}
+
+auto PlayerLoginDataMessage::getFaction() const -> Faction
+{
+  return m_faction;
+}
+
+auto PlayerLoginDataMessage::getActiveShipDbId() const -> Uuid
+{
+  return m_activeShipDbId;
+}
+
+bool PlayerLoginDataMessage::isDocked() const
+{
+  return m_docked;
+}
+
+auto PlayerLoginDataMessage::serialize(std::ostream &out) const -> std::ostream &
+{
+  core::serialize(out, m_messageType);
+  core::serialize(out, m_clientId);
+
+  core::serialize(out, m_faction);
+  core::serialize(out, m_activeShipDbId);
+  core::serialize(out, m_docked);
+
+  return out;
+}
+
+bool PlayerLoginDataMessage::deserialize(std::istream &in)
+{
+  bool ok{true};
+  ok &= core::deserialize(in, m_messageType);
+  ok &= core::deserialize(in, m_clientId);
+
+  ok &= core::deserialize(in, m_faction);
+  ok &= core::deserialize(in, m_activeShipDbId);
+  ok &= core::deserialize(in, m_docked);
+
+  return ok;
+}
+
+auto PlayerLoginDataMessage::clone() const -> IMessagePtr
+{
+  auto clone = std::make_unique<PlayerLoginDataMessage>(m_faction, m_activeShipDbId, m_docked);
+  clone->copyClientIdIfDefined(*this);
+
+  return clone;
+}
+
+} // namespace bsgo

--- a/src/bsgo/messages/loading/PlayerLoginDataMessage.hh
+++ b/src/bsgo/messages/loading/PlayerLoginDataMessage.hh
@@ -1,0 +1,32 @@
+
+#pragma once
+
+#include "Faction.hh"
+#include "NetworkMessage.hh"
+#include "Uuid.hh"
+
+namespace bsgo {
+
+class PlayerLoginDataMessage : public NetworkMessage
+{
+  public:
+  PlayerLoginDataMessage();
+  PlayerLoginDataMessage(const Faction faction, const Uuid activeShipDbId, const bool docked);
+  ~PlayerLoginDataMessage() override = default;
+
+  auto getFaction() const -> Faction;
+  auto getActiveShipDbId() const -> Uuid;
+  bool isDocked() const;
+
+  auto serialize(std::ostream &out) const -> std::ostream & override;
+  bool deserialize(std::istream &in) override;
+
+  auto clone() const -> IMessagePtr override;
+
+  private:
+  Faction m_faction{};
+  Uuid m_activeShipDbId{};
+  bool m_docked{};
+};
+
+} // namespace bsgo

--- a/src/bsgo/services/LoadingService.cc
+++ b/src/bsgo/services/LoadingService.cc
@@ -11,6 +11,18 @@ LoadingService::LoadingService(const Repositories &repositories,
   , m_entityMapper(entityMapper)
 {}
 
+auto LoadingService::getDataForPlayer(const Uuid playerDbId) const -> PlayerProps
+{
+  const auto player = m_repositories.playerRepository->findOneById(playerDbId);
+  const auto ship   = m_repositories.playerShipRepository->findOneByPlayerAndActive(playerDbId);
+
+  return {
+    .faction  = player.faction,
+    .shipDbId = ship.id,
+    .docked   = ship.docked,
+  };
+}
+
 auto LoadingService::getPlayersInSystem(const Uuid systemDbId) const -> std::vector<Player>
 {
   const auto playerIds = m_repositories.playerRepository->findAllBySystem(systemDbId);

--- a/src/bsgo/services/LoadingService.hh
+++ b/src/bsgo/services/LoadingService.hh
@@ -21,6 +21,14 @@ class LoadingService : public AbstractService
                  const DatabaseEntityMapper &entityMapper);
   ~LoadingService() override = default;
 
+  struct PlayerProps
+  {
+    Faction faction{};
+    Uuid shipDbId{};
+    bool docked{};
+  };
+  auto getDataForPlayer(const Uuid playerDbId) const -> PlayerProps;
+
   auto getPlayersInSystem(const Uuid systemDbId) const -> std::vector<Player>;
 
   struct AsteroidProps

--- a/src/client/lib/game/CMakeLists.txt
+++ b/src/client/lib/game/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources (client_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/Screen.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/Game.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/GameMessageModule.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/GameSession.cc
 	)
 
 target_include_directories (client_lib PUBLIC

--- a/src/client/lib/game/Game.hh
+++ b/src/client/lib/game/Game.hh
@@ -7,6 +7,7 @@
 #include "CoreObject.hh"
 #include "DataSource.hh"
 #include "DatabaseEntityMapper.hh"
+#include "GameSession.hh"
 #include "IInputHandler.hh"
 #include "IRenderer.hh"
 #include "IUiHandler.hh"
@@ -62,9 +63,10 @@ class Game : public core::CoreObject
 
   void onConnectedToServer(const bsgo::Uuid clientId);
   void onLogin(const bsgo::Uuid playerDbId);
+  void onLoginDataReceived(const bsgo::Uuid playerShipDbId);
   void onLogout();
-  void onActiveShipChanged();
-  void onActiveSystemChanged();
+  void onActiveShipChanged(const bsgo::Uuid shipDbId);
+  void onActiveSystemChanged(const bsgo::Uuid systemDbId);
   void onShipDocked();
   void onShipUndocked();
   void onPlayerKilled();
@@ -80,7 +82,7 @@ class Game : public core::CoreObject
   {
     /// @brief - Defines the current screen selected in this game. Updated whenever
     /// the user takes action to change it.
-    Screen screen;
+    Screen screen{Screen::LOGIN};
 
     /// @brief - Whether the game was terminated (usually because the app was closed).
     bool terminated{false};
@@ -89,30 +91,11 @@ class Game : public core::CoreObject
     bool dead{false};
   };
 
-  /// @brief - The data associated with the current gaming session. This
-  /// include information about the player (such as the current system,
-  /// the ID of the player in the DB) but also about the game in general
-  /// such as the next screen to be displayed when waiting for loading
-  /// data to be communicated by the server.
-  struct GameSession
-  {
-    std::optional<bsgo::Uuid> systemDbId{};
-    std::optional<bsgo::Uuid> playerDbId{};
-
-    std::optional<bsgo::LoadingTransition> transition{};
-
-    /// @brief - holds the screen that was displayed before the current
-    /// loading phase.
-    std::optional<Screen> previousScreen{};
-
-    /// @brief - holds the screen that should be displayed after the
-    /// loading phase is finished.
-    std::optional<Screen> nextScreen{};
-  };
-
   /// @brief - The definition of the game state.
   State m_state{};
 
+  /// @brief - Holds information about the current game session. This includes
+  /// data about the current player, their ship, the system they are in, etc.
   GameSession m_gameSession{};
 
   bsgo::DataSource m_dataSource{bsgo::DataLoadingMode::CLIENT};

--- a/src/client/lib/game/GameMessageModule.cc
+++ b/src/client/lib/game/GameMessageModule.cc
@@ -15,7 +15,8 @@ const Messages GAME_CHANGING_MESSAGE_TYPES = {bsgo::MessageType::CONNECTION,
                                               bsgo::MessageType::SIGNUP,
                                               bsgo::MessageType::ENTITY_REMOVED,
                                               bsgo::MessageType::LOADING_STARTED,
-                                              bsgo::MessageType::LOADING_FINISHED};
+                                              bsgo::MessageType::LOADING_FINISHED,
+                                              bsgo::MessageType::PLAYER_LOGIN_DATA};
 
 GameMessageModule::GameMessageModule(Game &game, const bsgo::DatabaseEntityMapper &entityMapper)
   : bsgo::AbstractMessageListener(GAME_CHANGING_MESSAGE_TYPES)
@@ -60,6 +61,9 @@ void GameMessageModule::onMessageReceived(const bsgo::IMessage &message)
     case bsgo::MessageType::LOADING_FINISHED:
       handleLoadingFinishedMessage(message.as<bsgo::LoadingFinishedMessage>());
       break;
+    case bsgo::MessageType::PLAYER_LOGIN_DATA:
+      handlePlayerLoginDataMessage(message.as<bsgo::PlayerLoginDataMessage>());
+      break;
     default:
       error("Unsupported message type " + bsgo::str(message.type()));
       break;
@@ -100,7 +104,7 @@ void GameMessageModule::handleHangarMessage(const bsgo::HangarMessage &message)
     return;
   }
 
-  m_game.onActiveShipChanged();
+  m_game.onActiveShipChanged(message.getShipDbId());
 }
 
 void GameMessageModule::handleJumpMessage(const bsgo::JumpMessage &message)
@@ -113,7 +117,8 @@ void GameMessageModule::handleJumpMessage(const bsgo::JumpMessage &message)
     return;
   }
 
-  m_game.onActiveSystemChanged();
+  const auto systemDbId = message.getDestinationSystemDbId();
+  m_game.onActiveSystemChanged(systemDbId);
 }
 
 void GameMessageModule::handleLoginMessage(const bsgo::LoginMessage &message)
@@ -162,6 +167,11 @@ void GameMessageModule::handleLoadingStartedMessage(const bsgo::LoadingStartedMe
 void GameMessageModule::handleLoadingFinishedMessage(const bsgo::LoadingFinishedMessage &message) const
 {
   m_game.onLoadingFinished(message.getTransition());
+}
+
+void GameMessageModule::handlePlayerLoginDataMessage(const bsgo::PlayerLoginDataMessage &message)
+{
+  m_game.onLoginDataReceived(message.getActiveShipDbId());
 }
 
 } // namespace pge

--- a/src/client/lib/game/GameMessageModule.hh
+++ b/src/client/lib/game/GameMessageModule.hh
@@ -16,6 +16,7 @@
 #include "LoadingStartedMessage.hh"
 #include "LoginMessage.hh"
 #include "LogoutMessage.hh"
+#include "PlayerLoginDataMessage.hh"
 #include "SignupMessage.hh"
 
 namespace pge {
@@ -44,6 +45,7 @@ class GameMessageModule : public bsgo::AbstractMessageListener, public core::Cor
   void handleEntityRemovedMessage(const bsgo::EntityRemovedMessage &message);
   void handleLoadingStartedMessage(const bsgo::LoadingStartedMessage &message) const;
   void handleLoadingFinishedMessage(const bsgo::LoadingFinishedMessage &message) const;
+  void handlePlayerLoginDataMessage(const bsgo::PlayerLoginDataMessage &message);
 };
 
 } // namespace pge

--- a/src/client/lib/game/GameSession.cc
+++ b/src/client/lib/game/GameSession.cc
@@ -1,0 +1,154 @@
+
+
+#include "GameSession.hh"
+
+namespace pge {
+
+GameSession::GameSession()
+  : core::CoreObject("game")
+{
+  addModule("session");
+}
+
+void GameSession::setupLoadingScreen(const Screen currentScreen, const Screen nextScreen)
+{
+  if (m_loading)
+  {
+    error("Unexpected loading screen transition", "Already in loading state");
+  }
+
+  m_loading = LoadingData{.previousScreen = currentScreen,
+                          .nextScreen     = nextScreen,
+                          .transition     = {}};
+
+  debug("Successfully setup loading screen to " + str(nextScreen) + " from " + str(currentScreen));
+}
+
+namespace {
+
+bool isTransitionValidForNextScreen(const bsgo::LoadingTransition transition,
+
+                                    const Screen nextScreen)
+
+{
+  switch (transition)
+  {
+    case bsgo::LoadingTransition::JUMP:
+      return nextScreen == Screen::GAME;
+    case bsgo::LoadingTransition::LOGIN:
+      return nextScreen == Screen::OUTPOST;
+    case bsgo::LoadingTransition::UNDOCK:
+      return nextScreen == Screen::GAME;
+    default:
+      return false;
+  }
+}
+
+} // namespace
+
+void GameSession::startLoadingTransition(const bsgo::LoadingTransition transition)
+{
+  if (!m_loading)
+  {
+    error("Unexpected start of loading transition", "Not in loading screen");
+  }
+  if (!isTransitionValidForNextScreen(transition, m_loading->nextScreen))
+  {
+    error("Unexpected start of loading transition",
+          "Transition " + bsgo::str(transition) + " does not match next screen "
+            + str(m_loading->nextScreen));
+  }
+
+  debug("Starting loading transition to " + str(m_loading->nextScreen));
+  m_loading->transition = transition;
+}
+
+auto GameSession::finishLoadingTransition(const bsgo::LoadingTransition transition)
+  -> ScreenTransition
+{
+  if (!m_loading)
+  {
+    error("Unexpected end of loading transition", "Not in loading screen");
+  }
+  if (!m_loading->transition || m_loading->transition != transition)
+  {
+    error("Unexpected end of loading transition", "Transition does not match");
+  }
+
+  const auto previousScreen = m_loading->previousScreen;
+  const auto nextScreen     = m_loading->nextScreen;
+
+  debug("Ending loading transition from " + str(previousScreen) + " to " + str(nextScreen));
+
+  m_loading.reset();
+
+  return {.previous = previousScreen, .next = nextScreen};
+}
+
+void GameSession::onPlayerLoggedIn(const bsgo::Uuid playerDbId)
+{
+  if (m_playerDbId)
+  {
+    error("Unexpected player login", "Already logged in as " + bsgo::str(*m_playerDbId));
+  }
+
+  m_playerDbId = playerDbId;
+
+  debug("Logged in as " + bsgo::str(playerDbId));
+}
+
+void GameSession::onPlayerLoggedOut()
+{
+  if (!m_playerDbId)
+  {
+    error("Unexpected player logout", "No player logged in");
+  }
+
+  debug("Logged out from " + bsgo::str(*m_playerDbId));
+
+  m_playerDbId.reset();
+  m_systemDbId.reset();
+  m_playerShipDbId.reset();
+}
+
+auto GameSession::getPlayerDbId() const -> bsgo::Uuid
+{
+  if (!m_playerDbId)
+  {
+    error("Failed to get player DB ID", "No player logged in");
+  }
+
+  return *m_playerDbId;
+}
+
+auto GameSession::getPlayerActiveShipDbId() const -> bsgo::Uuid
+{
+  if (!m_playerShipDbId)
+  {
+    error("Failed to get player ship DB ID", "No active ship");
+  }
+
+  return *m_playerShipDbId;
+}
+
+void GameSession::onActiveSystemChanged(const bsgo::Uuid systemDbId)
+{
+  m_systemDbId = systemDbId;
+  debug("Active system changed to " + bsgo::str(*m_systemDbId));
+}
+
+void GameSession::onActiveShipChanged(const bsgo::Uuid shipDbId)
+{
+  m_playerShipDbId = shipDbId;
+  debug("Active ship changed to " + bsgo::str(*m_playerShipDbId));
+}
+
+void GameSession::setScreen(const Screen screen)
+{
+  if (!m_playerDbId)
+  {
+    error("Failed to set screen to " + str(screen), "Not logged in");
+  }
+}
+
+} // namespace pge

--- a/src/client/lib/game/GameSession.cc
+++ b/src/client/lib/game/GameSession.cc
@@ -143,12 +143,4 @@ void GameSession::onActiveShipChanged(const bsgo::Uuid shipDbId)
   debug("Active ship changed to " + bsgo::str(*m_playerShipDbId));
 }
 
-void GameSession::setScreen(const Screen screen)
-{
-  if (!m_playerDbId)
-  {
-    error("Failed to set screen to " + str(screen), "Not logged in");
-  }
-}
-
 } // namespace pge

--- a/src/client/lib/game/GameSession.hh
+++ b/src/client/lib/game/GameSession.hh
@@ -43,8 +43,6 @@ class GameSession : public core::CoreObject
   void onActiveSystemChanged(const bsgo::Uuid systemDbId);
   void onActiveShipChanged(const bsgo::Uuid shipDbId);
 
-  void setScreen(const Screen screen);
-
   private:
   /// @brief - if defined, the DB identifier of the player currently logged in.
   std::optional<bsgo::Uuid> m_playerDbId{};

--- a/src/client/lib/game/GameSession.hh
+++ b/src/client/lib/game/GameSession.hh
@@ -1,0 +1,102 @@
+
+
+#pragma once
+
+#include "CoreObject.hh"
+#include "LoadingTransition.hh"
+#include "Screen.hh"
+#include "Uuid.hh"
+#include <optional>
+
+namespace pge {
+
+class GameSession : public core::CoreObject
+
+{
+  public:
+  GameSession();
+  ~GameSession() override = default;
+
+  void setupLoadingScreen(const Screen currentScreen, const Screen nextScreen);
+  void startLoadingTransition(const bsgo::LoadingTransition transition);
+
+  struct ScreenTransition
+
+  {
+    Screen previous{};
+    Screen next{};
+  };
+
+  auto finishLoadingTransition(const bsgo::LoadingTransition transition) -> ScreenTransition;
+
+  void onPlayerLoggedIn(const bsgo::Uuid playerDbId);
+  void onPlayerLoggedOut();
+
+  /// @brief - Returns the DB identifier of the player currently logged in.
+  /// If no player is logged in, an error is raised.
+  auto getPlayerDbId() const -> bsgo::Uuid;
+
+  /// @brief - Returns the DB identifier of the active ship for the player
+  /// currently logged in. If no ship is active, an error is raised.
+  auto getPlayerActiveShipDbId() const -> bsgo::Uuid;
+
+  void onActiveSystemChanged(const bsgo::Uuid systemDbId);
+  void onActiveShipChanged(const bsgo::Uuid shipDbId);
+
+  void setScreen(const Screen screen);
+
+  private:
+  /// @brief - if defined, the DB identifier of the player currently logged in.
+  std::optional<bsgo::Uuid> m_playerDbId{};
+
+  /// @brief - if defined, the DB identifier of the system the player is currently
+  /// in. It is populated when the player logs in and changed when the player jumps
+  /// to another system.
+  std::optional<bsgo::Uuid> m_systemDbId{};
+
+  /// @brief - if defined, the DB identifier of the active ship for the player. It
+  /// is not defined when the player initially logs in. It gets assigned when the
+  /// player leaves the outpost and changed when the player changes ship in the
+  /// hangar view in the outpost.
+  std::optional<bsgo::Uuid> m_playerShipDbId{};
+
+  struct LoadingData
+  {
+    /// @brief - holds the screen that was displayed before the current loading
+    /// phase.
+    Screen previousScreen{};
+
+    /// @brief - holds the screen that should be displayed after the loading phase
+    /// is finished.
+    Screen nextScreen{};
+
+    /// @brief - if defined, represents the loading transition received from the
+    /// server. It is set upon receiving a `LoadingStartedMessage` and is unset
+    /// upon receiving a `LoadingFinishedMessage`.
+    std::optional<bsgo::LoadingTransition> transition{};
+  };
+
+  /// @brief - if defined, the current loading transition. The process is that:
+  /// 1. the client application requests a change of screen (which will set both
+  /// the value of `m_previousScreen` and `m_nextScreen`).
+  /// 2. the server acknowledges the request and sends a `LoadingStartedMessage`
+  ///    with the transition.
+  /// 3. the client controls the value sent in the `LoadingStartedMessage` and
+  ///    sets thie value. It will remain active for the duration of the loading
+  ///    process.
+  /// 4. some data is sent by the server corresponding to the current loading
+  ///    phase.
+  /// 5. the server sends a `LoadingFinishedMessage` with the same transition.
+  /// 6. the client checks that the transition matches the one set in step 3.
+  /// 7. the screen to transition to is made available as a result of calling
+  ///   `finishLoadingTransition`.
+  /// This logic is encapsulated in three methods:
+  /// - `setupLoadingScreen`: prepares for a loading transition
+  /// - `startLoadingTransition`: acknowledges that the transition mathces what
+  ///   was setup
+  /// - `finishLoadingTransition`: moves to the next screen and resets the
+  ///   transition
+  std::optional<LoadingData> m_loading{};
+};
+
+} // namespace pge

--- a/src/server/lib/consumers/system/LoadingMessagesConsumer.hh
+++ b/src/server/lib/consumers/system/LoadingMessagesConsumer.hh
@@ -24,6 +24,7 @@ class LoadingMessagesConsumer : public AbstractMessageConsumer
   void handleLoadingStartedMessage(const LoadingStartedMessage &message) const;
   void forwardLoadingFinishedMessage(const LoadingFinishedMessage &message) const;
 
+  void handleLoginDataLoading(const LoadingStartedMessage &message) const;
   void handlePlayersLoading(const LoadingStartedMessage &message) const;
   void handleAsteroidsLoading(const LoadingStartedMessage &message) const;
   void handleOutpostsLoading(const LoadingStartedMessage &message) const;

--- a/tests/unit/bsgo/messages/loading/CMakeLists.txt
+++ b/tests/unit/bsgo/messages/loading/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(unitTests PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}/OutpostDataTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/OutpostListMessageTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/PlayerListMessageTest.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/PlayerLoginDataMessageTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/ShipDataTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/ShipListMessageTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/WeaponDataTest.cc

--- a/tests/unit/bsgo/messages/loading/PlayerLoginDataMessageTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerLoginDataMessageTest.cc
@@ -1,0 +1,51 @@
+
+#include "PlayerLoginDataMessage.hh"
+#include "Common.hh"
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+namespace bsgo {
+namespace {
+auto assertMessagesAreEqual(const PlayerLoginDataMessage &actual,
+                            const PlayerLoginDataMessage &expected)
+{
+  EXPECT_EQ(actual.type(), expected.type());
+  EXPECT_EQ(actual.tryGetClientId(), expected.tryGetClientId());
+  EXPECT_EQ(actual.getFaction(), expected.getFaction());
+  EXPECT_EQ(actual.getActiveShipDbId(), expected.getActiveShipDbId());
+  EXPECT_EQ(actual.isDocked(), expected.isDocked());
+}
+} // namespace
+
+TEST(Unit_Bsgo_Serialization_PlayerLoginDataMessage, Basic)
+{
+  const PlayerLoginDataMessage expected(Faction::CYLON, Uuid{8712}, true);
+  PlayerLoginDataMessage actual(Faction::COLONIAL, Uuid{1515}, false);
+  actual.setClientId(Uuid{2});
+
+  serializeAndDeserializeMessage(expected, actual);
+
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_PlayerLoginDataMessage, WithClientId)
+{
+  PlayerLoginDataMessage expected(Faction::COLONIAL, Uuid{123}, false);
+  expected.setClientId(Uuid{78});
+  PlayerLoginDataMessage actual(Faction::CYLON, Uuid{745}, true);
+
+  serializeAndDeserializeMessage(expected, actual);
+
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_PlayerLoginDataMessage, Clone)
+{
+  const PlayerLoginDataMessage expected(Faction::CYLON, Uuid{4572}, true);
+  const auto cloned = expected.clone();
+  ASSERT_EQ(cloned->type(), MessageType::PLAYER_LOGIN_DATA);
+  assertMessagesAreEqual(cloned->as<PlayerLoginDataMessage>(), expected);
+}
+
+} // namespace bsgo


### PR DESCRIPTION
# Work

## Context

The client application is currently loading most of the data directly from the database. This is not ideal for several reasons, the main one being that in a client/server architecture it would force to expose the database connection to the outside world.

## How to fix it?

Loading the data when a client connects to the server should follow the same logic as for the rest of the data: through messages. In order to do this, we first need to make the server able to produce such messages.

**Note:** the plan is laid out in more details in #9.

## Login data

Loading data in the client application is based on a couple of main values:
* the identifier of the player in the database
* the identifier of its currently active ship
* the identifier of the system the player is currently in

Those values are gathered in different ways. The first step happens upon login when the server returns the player identifier. From this point on the client application is able to determine the ship and system identifiers when loading the data for the system. This uses the database.

In order to improve the logic and decouple the loading from the database the client application needs to have another way to determine those values. To this end, this PR adds a new loading message, `PlayerLoginDataMessage`, which contains the necessary information to initialize the client app. Currently, it contains the faction of the player, the active ship identifier and the system identifier.

## Game session

The values described in the previous section need to be persisted in the client application and are using throughout the game session to display various elements such as:
* information in the outpost (hangar, available items, etc.)
* information in the HUD (weapons, reload time, etc.)

Currently the session is split into multiple parts:
* some of it is in the `DataSource` and used to load information from the database
* some of it is in the `Game` and can be used by the UI views

Additionally there's some logic to handle the loading process that is scattered in the `Game` class and needs to be verified and accessed in multiple places.

To consolidate this process, this PR introduces a new `GameSession` class which handles all of this. This makes further modifications of the logic easier as it's centralized in a single place.

## Changes in the `Game` class

With the introduction of the `GameSession` and the `PlayerLoginDataMessage`, the `Game` class can be simplified. Notably it does not need to keep track of which loading transition is active, or to have logic to determine the player identifier.

This is reflected in this PR where it takes advantage of the information that the loading messages provide. Specifically:
* the `onActiveSystemChanged` contains information about the new system
* so does the `JumpMessage`
* the `PlayerLoginDataMessage` contains information about the player and ship identifier
* the `HangarMessage` also contains information about the ship identifier

This is now used forwarded to the `GameSession` and available in the `Game` class when needed.

# Tests

We could verify locally that the new message is received by the client application:

![image](https://github.com/user-attachments/assets/7ac7eac9-5fe1-486b-8391-868d6f1828f7)

Additionally the rest of the player's journey (jumping to another system, docking, logout) works as before. 

# Future work

With the `GameSession` and the additional information sent by the server we can now really start to change the triggers for transitioning from one state to the next and change the way we fetch the data.

This will be done in #9.
