### PR TITLE
refactor: Used data struct in the data sources

### DIFF
--- a/src/bsgo/data/AsteroidDataSource.cc
+++ b/src/bsgo/data/AsteroidDataSource.cc
@@ -5,6 +5,13 @@
 
 namespace bsgo {
 
+AsteroidDataSource::AsteroidDataSource()
+  : core::CoreObject("bsgo")
+{
+  setService("data");
+  addModule("asteroid");
+}
+
 AsteroidDataSource::AsteroidDataSource(const Repositories &repositories)
   : core::CoreObject("bsgo")
   , m_repositories(repositories)
@@ -30,6 +37,29 @@ void AsteroidDataSource::initialize(const Uuid systemDbId,
 }
 
 void AsteroidDataSource::registerAsteroid(Coordinator &coordinator,
+                                          const AsteroidData data,
+                                          DatabaseEntityMapper &entityMapper) const
+
+{
+  const auto asteroidEntityId = coordinator.createEntity(EntityKind::ASTEROID);
+
+  coordinator.addDbId(asteroidEntityId, data.dbId);
+  auto box = std::make_unique<CircleBox>(data.position, data.radius);
+  coordinator.addTransform(asteroidEntityId, std::move(box));
+  coordinator.addHealth(asteroidEntityId, data.health, data.health, 0.0f);
+  coordinator.addRemoval(asteroidEntityId);
+  coordinator.addScanned(asteroidEntityId);
+  if (data.resource && data.amount)
+  {
+    coordinator.addLoot(asteroidEntityId);
+    coordinator.addResourceComponent(asteroidEntityId, *data.resource, *data.amount);
+  }
+  coordinator.addNetwork(asteroidEntityId, {ComponentType::HEALTH});
+
+  entityMapper.registerAsteroid(data.dbId, asteroidEntityId);
+}
+
+void AsteroidDataSource::registerAsteroid(Coordinator &coordinator,
                                           const Uuid asteroidDbId,
                                           DatabaseEntityMapper &entityMapper) const
 {
@@ -42,22 +72,21 @@ void AsteroidDataSource::registerAsteroid(Coordinator &coordinator,
 
   const auto data = m_repositories->asteroidRepository->findOneById(asteroidDbId);
 
-  auto box                    = std::make_unique<CircleBox>(data.position, data.radius);
-  const auto asteroidEntityId = coordinator.createEntity(EntityKind::ASTEROID);
-  coordinator.addDbId(asteroidEntityId, asteroidDbId);
-  coordinator.addTransform(asteroidEntityId, std::move(box));
-  coordinator.addHealth(asteroidEntityId, data.health, data.health, 0.0f);
-  coordinator.addRemoval(asteroidEntityId);
-  coordinator.addScanned(asteroidEntityId);
+  AsteroidData out{
+    .dbId     = asteroidDbId,
+    .position = data.position,
+    .radius   = data.radius,
+    .health   = data.health,
+  };
+
   if (data.loot)
   {
-    coordinator.addLoot(asteroidEntityId);
     const auto loot = m_repositories->asteroidLootRepository->findOneById(asteroidDbId);
-    coordinator.addResourceComponent(asteroidEntityId, loot.resource, loot.amount);
+    out.resource    = loot.resource;
+    out.amount      = loot.amount;
   }
-  coordinator.addNetwork(asteroidEntityId, {ComponentType::HEALTH});
 
-  entityMapper.registerAsteroid(asteroidDbId, asteroidEntityId);
+  registerAsteroid(coordinator, out, entityMapper);
 }
 
 } // namespace bsgo

--- a/src/bsgo/data/AsteroidDataSource.hh
+++ b/src/bsgo/data/AsteroidDataSource.hh
@@ -14,13 +14,17 @@ class Coordinator;
 class AsteroidDataSource : public core::CoreObject
 {
   public:
-  AsteroidDataSource() = default;
+  AsteroidDataSource();
   AsteroidDataSource(const Repositories &repositories);
   ~AsteroidDataSource() override = default;
 
   void initialize(const Uuid systemDbId,
                   Coordinator &coordinator,
                   DatabaseEntityMapper &entityMapper) const;
+
+  void registerAsteroid(Coordinator &coordinator,
+                        const AsteroidData data,
+                        DatabaseEntityMapper &entityMapper) const;
 
   void registerAsteroid(Coordinator &coordinator,
                         const Uuid asteroidDbId,


### PR DESCRIPTION
# Work

## Context

The client application is currently loading most of the data directly from the database. This is not ideal for several reasons, the main one being that in a client/server architecture it would force to expose the database connection to the outside world.

## How to fix it?

Loading the data when a client connects to the server should follow the same logic as for the rest of the data: through messages. In order to do this, we first need to make the server able to produce such messages.

**Note:** the plan is laid out in more details in #9.

## Key changes

:information_source: **Note:** we'll take the example of the asteroids here but this logic applies to other entities (e.g. ships and outposts).

In #9 we need to interpret the loading messages received from the server. This means receiving a list of `AsteroidData` structs and interpreting them in the `AsteroidListMessageConsumer` to populate the local ECS.

There's currently a dedicated method in the `AsteroidDataSource`, `registerAsteroid` which has the following prototype:

```cpp
  void registerAsteroid(Coordinator &coordinator,
                        const Uuid asteroidDbId,
                        DatabaseEntityMapper &entityMapper) const;
```

The problem with this is that it takes the asteroid database identifier and proceeds to load the data from the database to build the entity. This is not what we want in the client application.

In this PR we build on #27 and add a new method:

```cpp
  void registerAsteroid(Coordinator &coordinator,
                        const AsteroidData data,
                        DatabaseEntityMapper &entityMapper) const;
```

This method is directly callable from the `AsteroidListMessageConsumer` as we receive a `AsteroidData` struct from the server. Additionally, we can modify the existing `registerAsteroid` to build a `AsteroidData` struct and call the same method.

In the future when the client application does not know about the database anymore we can make the original method (the one taking a database identifier) private and throw an exception in the `initialize` method if the loading mode is not `SERVER`.

# Tests

The client application is still able to load the data from the server correctly.

# Future work

We can use this work in #9 to reduce code duplication between what is done in the `DataSource` and the consumers for the loading messages. With the work in this PR it is easy to just call the `registerXYZ` methods in the corresponding data source to interpret the data received from the server.
