### PR TITLE
feat: EntityAddedMessage now carries loading data

### DIFF
--- a/src/bsgo/data/AsteroidDataSource.cc
+++ b/src/bsgo/data/AsteroidDataSource.cc
@@ -63,13 +63,6 @@ void AsteroidDataSource::registerAsteroid(Coordinator &coordinator,
                                           const Uuid asteroidDbId,
                                           DatabaseEntityMapper &entityMapper) const
 {
-  // TODO: This will become private when the EntityAddedMessage is using the
-  // AsteroidData.
-  if (!m_repositories)
-  {
-    error("Failed to register asteroid", "Repositories are not set");
-  }
-
   const auto data = m_repositories->asteroidRepository->findOneById(asteroidDbId);
 
   AsteroidData out{

--- a/src/bsgo/data/AsteroidDataSource.hh
+++ b/src/bsgo/data/AsteroidDataSource.hh
@@ -26,12 +26,12 @@ class AsteroidDataSource : public core::CoreObject
                         const AsteroidData &data,
                         DatabaseEntityMapper &entityMapper) const;
 
+  private:
+  std::optional<Repositories> m_repositories{};
+
   void registerAsteroid(Coordinator &coordinator,
                         const Uuid asteroidDbId,
                         DatabaseEntityMapper &entityMapper) const;
-
-  private:
-  std::optional<Repositories> m_repositories{};
 };
 
 } // namespace bsgo

--- a/src/bsgo/data/PlayerDataSource.cc
+++ b/src/bsgo/data/PlayerDataSource.cc
@@ -28,7 +28,7 @@ void PlayerDataSource::initialize(const Uuid systemDbId,
     error("Failed to initialize outpost", "Repositories are not set");
   }
 
-  const auto players = m_repositories->playerRepository->findAllBySystem(systemDbId);
+  const auto players = m_repositories->playerRepository->findAllUndockedBySystem(systemDbId);
   for (const auto &id : players)
   {
     registerPlayer(coordinator, id, entityMapper);

--- a/src/bsgo/messages/EntityAddedMessage.cc
+++ b/src/bsgo/messages/EntityAddedMessage.cc
@@ -34,6 +34,7 @@ void EntityAddedMessage::setAsteroidData(const AsteroidData &data)
   m_asteroidData = data;
   m_shipData.reset();
   m_outpostData.reset();
+  m_playerData.reset();
 }
 
 auto EntityAddedMessage::tryGetAsteroidData() const -> std::optional<AsteroidData>
@@ -47,6 +48,7 @@ void EntityAddedMessage::setShipData(const ShipData &data)
   m_asteroidData.reset();
   m_shipData = data;
   m_outpostData.reset();
+  m_playerData.reset();
 }
 
 auto EntityAddedMessage::tryGetShipData() const -> std::optional<ShipData>
@@ -60,11 +62,26 @@ void EntityAddedMessage::setOutpostData(const OutpostData &data)
   m_asteroidData.reset();
   m_shipData.reset();
   m_outpostData = data;
+  m_playerData.reset();
 }
 
 auto EntityAddedMessage::tryGetOutpostData() const -> std::optional<OutpostData>
 {
   return m_outpostData;
+}
+
+void EntityAddedMessage::setPlayerData(const PlayerData &data)
+{
+  m_entityKind = EntityKind::PLAYER;
+  m_asteroidData.reset();
+  m_shipData.reset();
+  m_outpostData.reset();
+  m_playerData = data;
+}
+
+auto EntityAddedMessage::tryGetPlayerData() const -> std::optional<PlayerData>
+{
+  return m_playerData;
 }
 
 auto EntityAddedMessage::serialize(std::ostream &out) const -> std::ostream &
@@ -90,6 +107,9 @@ auto EntityAddedMessage::serialize(std::ostream &out) const -> std::ostream &
       break;
     case EntityKind::OUTPOST:
       serializeOutpostData(out, *m_outpostData);
+      break;
+    case EntityKind::PLAYER:
+      serializePlayerData(out, *m_playerData);
       break;
     default:
       error("Unsupported entity kind for serialization: " + str(*m_entityKind));
@@ -141,6 +161,20 @@ auto deserializeOutpostData(std::istream &in, std::optional<OutpostData> &outpos
 
   return ok;
 }
+
+auto deserializePlayerData(std::istream &in, std::optional<PlayerData> &player) -> bool
+{
+  PlayerData data{};
+  bool ok = deserializePlayerData(in, data);
+
+  player.reset();
+  if (ok)
+  {
+    player = data;
+  }
+
+  return ok;
+}
 } // namespace
 
 bool EntityAddedMessage::deserialize(std::istream &in)
@@ -169,6 +203,9 @@ bool EntityAddedMessage::deserialize(std::istream &in)
       break;
     case EntityKind::OUTPOST:
       ok &= deserializeOutpostData(in, m_outpostData);
+      break;
+    case EntityKind::PLAYER:
+      ok &= deserializePlayerData(in, m_playerData);
       break;
     default:
       error("Unsupported entity kind for deserialization: " + str(*m_entityKind));

--- a/src/bsgo/messages/EntityAddedMessage.cc
+++ b/src/bsgo/messages/EntityAddedMessage.cc
@@ -1,5 +1,6 @@
 
 #include "EntityAddedMessage.hh"
+#include "DataSerialization.hh"
 #include "SerializationUtils.hh"
 
 namespace bsgo {
@@ -8,28 +9,62 @@ EntityAddedMessage::EntityAddedMessage()
   : NetworkMessage(MessageType::ENTITY_ADDED)
 {}
 
-EntityAddedMessage::EntityAddedMessage(const Uuid entityDbId,
-                                       const EntityKind entityKind,
-                                       const Uuid systemDbId)
+EntityAddedMessage::EntityAddedMessage(const Uuid systemDbId)
   : NetworkMessage(MessageType::ENTITY_ADDED)
-  , m_entityDbId(entityDbId)
-  , m_entityKind(entityKind)
   , m_systemDbId(systemDbId)
 {}
-
-auto EntityAddedMessage::getEntityDbId() const -> Uuid
-{
-  return m_entityDbId;
-}
-
-auto EntityAddedMessage::getEntityKind() const -> EntityKind
-{
-  return m_entityKind;
-}
 
 auto EntityAddedMessage::getSystemDbId() const -> Uuid
 {
   return m_systemDbId;
+}
+
+auto EntityAddedMessage::getEntityKind() const -> EntityKind
+{
+  if (!m_entityKind)
+  {
+    error("Expected entity kind to be defined but it was not");
+  }
+  return *m_entityKind;
+}
+
+void EntityAddedMessage::setAsteroidData(const AsteroidData &data)
+{
+  m_entityKind   = EntityKind::ASTEROID;
+  m_asteroidData = data;
+  m_shipData.reset();
+  m_outpostData.reset();
+}
+
+auto EntityAddedMessage::tryGetAsteroidData() const -> std::optional<AsteroidData>
+{
+  return m_asteroidData;
+}
+
+void EntityAddedMessage::setShipData(const ShipData &data)
+{
+  m_entityKind = EntityKind::SHIP;
+  m_asteroidData.reset();
+  m_shipData = data;
+  m_outpostData.reset();
+}
+
+auto EntityAddedMessage::tryGetShipData() const -> std::optional<ShipData>
+{
+  return m_shipData;
+}
+
+void EntityAddedMessage::setOutpostData(const OutpostData &data)
+{
+  m_entityKind = EntityKind::OUTPOST;
+  m_asteroidData.reset();
+  m_shipData.reset();
+  m_outpostData = data;
+}
+
+auto EntityAddedMessage::tryGetOutpostData() const -> std::optional<OutpostData>
+{
+  return m_outpostData;
 }
 
 auto EntityAddedMessage::serialize(std::ostream &out) const -> std::ostream &
@@ -37,12 +72,76 @@ auto EntityAddedMessage::serialize(std::ostream &out) const -> std::ostream &
   core::serialize(out, m_messageType);
   core::serialize(out, m_clientId);
 
-  core::serialize(out, m_entityDbId);
-  core::serialize(out, m_entityKind);
+  if (!m_entityKind)
+  {
+    error("Expected entity kind to be defined but it was not");
+  }
+
   core::serialize(out, m_systemDbId);
+  core::serialize(out, *m_entityKind);
+
+  switch (*m_entityKind)
+  {
+    case EntityKind::ASTEROID:
+      serializeAsteroidData(out, *m_asteroidData);
+      break;
+    case EntityKind::SHIP:
+      serializeShipData(out, *m_shipData);
+      break;
+    case EntityKind::OUTPOST:
+      serializeOutpostData(out, *m_outpostData);
+      break;
+    default:
+      error("Unsupported entity kind for serialization: " + str(*m_entityKind));
+      break;
+  }
 
   return out;
 }
+
+namespace {
+auto deserializeAsteroidData(std::istream &in, std::optional<AsteroidData> &asteroid) -> bool
+{
+  AsteroidData data{};
+  bool ok = deserializeAsteroidData(in, data);
+
+  asteroid.reset();
+  if (ok)
+  {
+    asteroid = data;
+  }
+
+  return ok;
+}
+
+auto deserializeShipData(std::istream &in, std::optional<ShipData> &ship) -> bool
+{
+  ShipData data{};
+  bool ok = deserializeShipData(in, data);
+
+  ship.reset();
+  if (ok)
+  {
+    ship = data;
+  }
+
+  return ok;
+}
+
+auto deserializeOutpostData(std::istream &in, std::optional<OutpostData> &outpost) -> bool
+{
+  OutpostData data{};
+  bool ok = deserializeOutpostData(in, data);
+
+  outpost.reset();
+  if (ok)
+  {
+    outpost = data;
+  }
+
+  return ok;
+}
+} // namespace
 
 bool EntityAddedMessage::deserialize(std::istream &in)
 {
@@ -50,16 +149,54 @@ bool EntityAddedMessage::deserialize(std::istream &in)
   ok &= core::deserialize(in, m_messageType);
   ok &= core::deserialize(in, m_clientId);
 
-  ok &= core::deserialize(in, m_entityDbId);
-  ok &= core::deserialize(in, m_entityKind);
   ok &= core::deserialize(in, m_systemDbId);
+  // The serialization makes sure that the entity kind is always defined.
+  EntityKind kind{};
+  ok &= core::deserialize(in, kind);
+  m_entityKind = kind;
+
+  m_asteroidData.reset();
+  m_shipData.reset();
+  m_outpostData.reset();
+
+  switch (*m_entityKind)
+  {
+    case EntityKind::ASTEROID:
+      ok &= deserializeAsteroidData(in, m_asteroidData);
+      break;
+    case EntityKind::SHIP:
+      ok &= deserializeShipData(in, m_shipData);
+      break;
+    case EntityKind::OUTPOST:
+      ok &= deserializeOutpostData(in, m_outpostData);
+      break;
+    default:
+      error("Unsupported entity kind for deserialization: " + str(*m_entityKind));
+      break;
+  }
 
   return ok;
 }
 
 auto EntityAddedMessage::clone() const -> IMessagePtr
 {
-  auto clone = std::make_unique<EntityAddedMessage>(m_entityDbId, m_entityKind, m_systemDbId);
+  auto clone = std::make_unique<EntityAddedMessage>(m_systemDbId);
+  switch (*m_entityKind)
+  {
+    case EntityKind::ASTEROID:
+      clone->setAsteroidData(*m_asteroidData);
+      break;
+    case EntityKind::SHIP:
+      clone->setShipData(*m_shipData);
+      break;
+    case EntityKind::OUTPOST:
+      clone->setOutpostData(*m_outpostData);
+      break;
+    default:
+      error("Unsupported entity kind for cloning: " + str(*m_entityKind));
+      break;
+  }
+
   clone->copyClientIdIfDefined(*this);
 
   return clone;

--- a/src/bsgo/messages/EntityAddedMessage.cc
+++ b/src/bsgo/messages/EntityAddedMessage.cc
@@ -229,6 +229,9 @@ auto EntityAddedMessage::clone() const -> IMessagePtr
     case EntityKind::OUTPOST:
       clone->setOutpostData(*m_outpostData);
       break;
+    case EntityKind::PLAYER:
+      clone->setPlayerData(*m_playerData);
+      break;
     default:
       error("Unsupported entity kind for cloning: " + str(*m_entityKind));
       break;

--- a/src/bsgo/messages/EntityAddedMessage.hh
+++ b/src/bsgo/messages/EntityAddedMessage.hh
@@ -2,8 +2,11 @@
 
 #pragma once
 
+#include "AsteroidData.hh"
 #include "EntityKind.hh"
 #include "NetworkMessage.hh"
+#include "OutpostData.hh"
+#include "ShipData.hh"
 #include "Uuid.hh"
 #include <optional>
 
@@ -13,12 +16,20 @@ class EntityAddedMessage : public NetworkMessage
 {
   public:
   EntityAddedMessage();
-  EntityAddedMessage(const Uuid entityDbId, const EntityKind entityKind, const Uuid systemDbId);
+  EntityAddedMessage(const Uuid systemDbId);
   ~EntityAddedMessage() override = default;
 
-  auto getEntityDbId() const -> Uuid;
-  auto getEntityKind() const -> EntityKind;
   auto getSystemDbId() const -> Uuid;
+  auto getEntityKind() const -> EntityKind;
+
+  void setAsteroidData(const AsteroidData &data);
+  auto tryGetAsteroidData() const -> std::optional<AsteroidData>;
+
+  void setShipData(const ShipData &data);
+  auto tryGetShipData() const -> std::optional<ShipData>;
+
+  void setOutpostData(const OutpostData &data);
+  auto tryGetOutpostData() const -> std::optional<OutpostData>;
 
   auto serialize(std::ostream &out) const -> std::ostream & override;
   bool deserialize(std::istream &in) override;
@@ -26,9 +37,12 @@ class EntityAddedMessage : public NetworkMessage
   auto clone() const -> IMessagePtr override;
 
   private:
-  Uuid m_entityDbId{};
-  EntityKind m_entityKind{};
   Uuid m_systemDbId{};
+  std::optional<EntityKind> m_entityKind{};
+
+  std::optional<AsteroidData> m_asteroidData{};
+  std::optional<ShipData> m_shipData{};
+  std::optional<OutpostData> m_outpostData{};
 };
 
 } // namespace bsgo

--- a/src/bsgo/messages/EntityAddedMessage.hh
+++ b/src/bsgo/messages/EntityAddedMessage.hh
@@ -6,6 +6,7 @@
 #include "EntityKind.hh"
 #include "NetworkMessage.hh"
 #include "OutpostData.hh"
+#include "PlayerData.hh"
 #include "ShipData.hh"
 #include "Uuid.hh"
 #include <optional>
@@ -31,6 +32,9 @@ class EntityAddedMessage : public NetworkMessage
   void setOutpostData(const OutpostData &data);
   auto tryGetOutpostData() const -> std::optional<OutpostData>;
 
+  void setPlayerData(const PlayerData &data);
+  auto tryGetPlayerData() const -> std::optional<PlayerData>;
+
   auto serialize(std::ostream &out) const -> std::ostream & override;
   bool deserialize(std::istream &in) override;
 
@@ -43,6 +47,7 @@ class EntityAddedMessage : public NetworkMessage
   std::optional<AsteroidData> m_asteroidData{};
   std::optional<ShipData> m_shipData{};
   std::optional<OutpostData> m_outpostData{};
+  std::optional<PlayerData> m_playerData{};
 };
 
 } // namespace bsgo

--- a/src/bsgo/repositories/PlayerRepository.hh
+++ b/src/bsgo/repositories/PlayerRepository.hh
@@ -28,7 +28,7 @@ class PlayerRepository : public AbstractRepository
   void initialize() override;
 
   auto findAll() const -> std::unordered_set<Uuid>;
-  auto findAllBySystem(const Uuid system) const -> std::unordered_set<Uuid>;
+  auto findAllUndockedBySystem(const Uuid system) const -> std::unordered_set<Uuid>;
   auto findOneById(const Uuid player) const -> Player;
   auto findOneByName(const std::string &name) const -> std::optional<Player>;
   auto findSystemByPlayer(const Uuid player) const -> Uuid;

--- a/src/bsgo/services/CMakeLists.txt
+++ b/src/bsgo/services/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources (bsgo_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/EntityService.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/JumpService.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LoadingService.cc
+	${CMAKE_CURRENT_SOURCE_DIR}/LoadingServiceUtils.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LoginService.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/LockerService.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/PurchaseService.cc

--- a/src/bsgo/services/EntityService.cc
+++ b/src/bsgo/services/EntityService.cc
@@ -46,22 +46,6 @@ bool EntityService::tryCreateShipEntity(const Uuid shipDbId) const
   return true;
 }
 
-bool EntityService::tryCreateAsteroidEntity(const Uuid asteroidDbId) const
-{
-  AsteroidDataSource source{m_repositories};
-  source.registerAsteroid(*m_coordinator, asteroidDbId, m_entityMapper);
-
-  const auto maybeEntityId = m_entityMapper.tryGetAsteroidEntityId(asteroidDbId);
-  if (!maybeEntityId)
-  {
-    warn("Failed to create entity for asteroid " + str(asteroidDbId),
-         "Registration did not create an entity for it");
-    return false;
-  }
-
-  return true;
-}
-
 void EntityService::tryDeleteShipEntity(const Uuid shipDbId) const
 {
   const auto maybeEntityId = m_entityMapper.tryGetShipEntityId(shipDbId);

--- a/src/bsgo/services/EntityService.cc
+++ b/src/bsgo/services/EntityService.cc
@@ -82,6 +82,17 @@ void EntityService::tryDeleteAsteroidEntity(const Uuid asteroidDbId) const
   m_entityMapper.removeEntityForAsteroid(asteroidDbId);
 }
 
+auto EntityService::tryGetPlayerDbIdForShip(const Uuid shipDbId) const -> std::optional<Uuid>
+{
+  const auto ship = m_repositories.playerShipRepository->findOneById(shipDbId);
+  if (!ship.player)
+  {
+    return {};
+  }
+
+  return ship.player;
+}
+
 void EntityService::handlePlayerCreationForShip(const Uuid &shipDbId) const
 {
   const auto ship = m_repositories.playerShipRepository->findOneById(shipDbId);

--- a/src/bsgo/services/EntityService.hh
+++ b/src/bsgo/services/EntityService.hh
@@ -20,7 +20,6 @@ class EntityService : public AbstractService
   ~EntityService() override = default;
 
   bool tryCreateShipEntity(const Uuid shipDbId) const;
-  bool tryCreateAsteroidEntity(const Uuid asteroidDbId) const;
   void tryDeleteShipEntity(const Uuid shipDbId) const;
   void tryDeleteAsteroidEntity(const Uuid asteroidDbId) const;
 

--- a/src/bsgo/services/EntityService.hh
+++ b/src/bsgo/services/EntityService.hh
@@ -23,6 +23,8 @@ class EntityService : public AbstractService
   void tryDeleteShipEntity(const Uuid shipDbId) const;
   void tryDeleteAsteroidEntity(const Uuid asteroidDbId) const;
 
+  auto tryGetPlayerDbIdForShip(const Uuid shipDbId) const -> std::optional<Uuid>;
+
   private:
   ProcessingMode m_processingMode{ProcessingMode::CLIENT};
   CoordinatorShPtr m_coordinator{};

--- a/src/bsgo/services/LoadingService.cc
+++ b/src/bsgo/services/LoadingService.cc
@@ -30,7 +30,7 @@ auto LoadingService::getPlayerById(const Uuid playerDbId) const -> Player
 
 auto LoadingService::getPlayersInSystem(const Uuid systemDbId) const -> std::vector<Player>
 {
-  const auto playerIds = m_repositories.playerRepository->findAllBySystem(systemDbId);
+  const auto playerIds = m_repositories.playerRepository->findAllUndockedBySystem(systemDbId);
 
   std::vector<Player> players{};
 

--- a/src/bsgo/services/LoadingService.cc
+++ b/src/bsgo/services/LoadingService.cc
@@ -38,6 +38,27 @@ auto LoadingService::getPlayersInSystem(const Uuid systemDbId) const -> std::vec
   return players;
 }
 
+auto LoadingService::getAsteroidById(const Uuid asteroidDbId) const -> AsteroidProps
+{
+  const auto asteroid = m_repositories.asteroidRepository->findOneById(asteroidDbId);
+
+  std::optional<Uuid> resource{};
+  std::optional<float> amount{};
+  if (asteroid.loot)
+  {
+    const auto loot = m_repositories.asteroidLootRepository->findOneById(asteroidDbId);
+    resource        = loot.resource;
+    amount          = loot.amount;
+  }
+
+  return AsteroidProps{
+    .dbId       = asteroidDbId,
+    .dbAsteroid = asteroid,
+    .resource   = resource,
+    .amount     = amount,
+  };
+}
+
 auto LoadingService::getAsteroidsInSystem(const Uuid systemDbId) const -> std::vector<AsteroidProps>
 {
   const auto asteroidDbIds = m_repositories.systemRepository->findAllAsteroidsBySystem(systemDbId);
@@ -78,6 +99,18 @@ auto getOutpostTargetDbId(const Uuid outpostDbId,
   return entity.targetComp().target();
 }
 } // namespace
+
+auto LoadingService::getOutpostById(const Uuid outpostDbId) const -> OutpostProps
+{
+  const auto outpost    = m_repositories.systemOutpostRepository->findOneById(outpostDbId);
+  const auto targetDbId = getOutpostTargetDbId(outpostDbId, m_entityMapper, *m_coordinator);
+
+  return OutpostProps{
+    .dbId       = outpostDbId,
+    .dbOutpost  = outpost,
+    .targetDbId = targetDbId,
+  };
+}
 
 auto LoadingService::getOutpostsInSystem(const Uuid systemDbId) const -> std::vector<OutpostProps>
 {
@@ -142,6 +175,23 @@ auto getShipTargetDbId(const Uuid shipDbId,
   return entity.targetComp().target();
 }
 } // namespace
+
+auto LoadingService::getShipById(const Uuid shipDbId) const -> ShipProps
+{
+  const auto ship       = m_repositories.playerShipRepository->findOneById(shipDbId);
+  const auto weapons    = getWeaponsForShip(m_repositories, shipDbId);
+  const auto computers  = getComputersForShip(m_repositories, shipDbId);
+  const auto status     = determineStartingStatusForShip(ship);
+  const auto targetDbId = getShipTargetDbId(shipDbId, m_entityMapper, *m_coordinator);
+
+  return ShipProps{
+    .dbShip     = ship,
+    .status     = status,
+    .targetDbId = targetDbId,
+    .weapons    = weapons,
+    .computers  = computers,
+  };
+}
 
 auto LoadingService::getShipsInSystem(const Uuid systemDbId) const -> std::vector<ShipProps>
 {

--- a/src/bsgo/services/LoadingService.cc
+++ b/src/bsgo/services/LoadingService.cc
@@ -23,6 +23,11 @@ auto LoadingService::getDataForPlayer(const Uuid playerDbId) const -> PlayerProp
   };
 }
 
+auto LoadingService::getPlayerById(const Uuid playerDbId) const -> Player
+{
+  return m_repositories.playerRepository->findOneById(playerDbId);
+}
+
 auto LoadingService::getPlayersInSystem(const Uuid systemDbId) const -> std::vector<Player>
 {
   const auto playerIds = m_repositories.playerRepository->findAllBySystem(systemDbId);
@@ -131,9 +136,9 @@ auto LoadingService::getOutpostsInSystem(const Uuid systemDbId) const -> std::ve
 
 namespace {
 auto getWeaponsForShip(const Repositories &repositories, const Uuid shipDbId)
-  -> std::vector<LoadingService::WeaponProps>
+  -> std::vector<WeaponProps>
 {
-  std::vector<LoadingService::WeaponProps> weapons{};
+  std::vector<WeaponProps> weapons{};
 
   const auto shipWeapons = repositories.shipWeaponRepository->findAllByShip(shipDbId);
   for (const auto &weapon : shipWeapons)

--- a/src/bsgo/services/LoadingService.hh
+++ b/src/bsgo/services/LoadingService.hh
@@ -4,6 +4,7 @@
 #include "AsteroidRepository.hh"
 #include "Coordinator.hh"
 #include "DatabaseEntityMapper.hh"
+#include "LoadingServiceUtils.hh"
 #include "PlayerRepository.hh"
 #include "PlayerShipRepository.hh"
 #include "Status.hh"
@@ -29,42 +30,15 @@ class LoadingService : public AbstractService
   };
   auto getDataForPlayer(const Uuid playerDbId) const -> PlayerProps;
 
+  auto getPlayerById(const Uuid playerDbId) const -> Player;
   auto getPlayersInSystem(const Uuid systemDbId) const -> std::vector<Player>;
 
-  struct AsteroidProps
-  {
-    Uuid dbId{};
-    Asteroid dbAsteroid{};
-
-    std::optional<Uuid> resource{};
-    std::optional<float> amount{};
-  };
   auto getAsteroidById(const Uuid asteroidDbId) const -> AsteroidProps;
   auto getAsteroidsInSystem(const Uuid systemDbId) const -> std::vector<AsteroidProps>;
 
-  struct OutpostProps
-  {
-    Uuid dbId{};
-    SystemOutpost dbOutpost{};
-    std::optional<Uuid> targetDbId{};
-  };
   auto getOutpostById(const Uuid outpostDbId) const -> OutpostProps;
   auto getOutpostsInSystem(const Uuid systemDbId) const -> std::vector<OutpostProps>;
 
-  struct WeaponProps
-  {
-    PlayerWeapon dbWeapon{};
-    Eigen::Vector3f slotPosition{Eigen::Vector3f::Zero()};
-  };
-
-  struct ShipProps
-  {
-    PlayerShip dbShip{};
-    Status status{};
-    std::optional<Uuid> targetDbId{};
-    std::vector<WeaponProps> weapons{};
-    std::vector<PlayerComputer> computers{};
-  };
   auto getShipById(const Uuid shipDbId) const -> ShipProps;
   auto getShipsInSystem(const Uuid systemDbId) const -> std::vector<ShipProps>;
 

--- a/src/bsgo/services/LoadingService.hh
+++ b/src/bsgo/services/LoadingService.hh
@@ -39,6 +39,7 @@ class LoadingService : public AbstractService
     std::optional<Uuid> resource{};
     std::optional<float> amount{};
   };
+  auto getAsteroidById(const Uuid asteroidDbId) const -> AsteroidProps;
   auto getAsteroidsInSystem(const Uuid systemDbId) const -> std::vector<AsteroidProps>;
 
   struct OutpostProps
@@ -47,6 +48,7 @@ class LoadingService : public AbstractService
     SystemOutpost dbOutpost{};
     std::optional<Uuid> targetDbId{};
   };
+  auto getOutpostById(const Uuid outpostDbId) const -> OutpostProps;
   auto getOutpostsInSystem(const Uuid systemDbId) const -> std::vector<OutpostProps>;
 
   struct WeaponProps
@@ -63,6 +65,7 @@ class LoadingService : public AbstractService
     std::vector<WeaponProps> weapons{};
     std::vector<PlayerComputer> computers{};
   };
+  auto getShipById(const Uuid shipDbId) const -> ShipProps;
   auto getShipsInSystem(const Uuid systemDbId) const -> std::vector<ShipProps>;
 
   private:

--- a/src/bsgo/services/LoadingServiceUtils.cc
+++ b/src/bsgo/services/LoadingServiceUtils.cc
@@ -1,0 +1,111 @@
+
+#include "LoadingServiceUtils.hh"
+
+namespace bsgo {
+
+auto toPlayerData(const Player &player) -> PlayerData
+{
+  return PlayerData{.dbId = player.id, .name = player.name};
+}
+
+auto AsteroidProps::toAsteroidData() const -> AsteroidData
+{
+  return AsteroidData{
+    .dbId     = dbId,
+    .position = dbAsteroid.position,
+    .radius   = dbAsteroid.radius,
+    .health   = dbAsteroid.health,
+    .resource = resource,
+    .amount   = amount,
+  };
+}
+
+auto OutpostProps::toOutpostData() const -> OutpostData
+{
+  return OutpostData{
+    .dbId            = dbId,
+    .position        = dbOutpost.position,
+    .radius          = dbOutpost.radius,
+    .hullPoints      = dbOutpost.hullPoints,
+    .maxHullPoints   = dbOutpost.maxHullPoints,
+    .hullPointsRegen = dbOutpost.hullPointsRegen,
+    .powerPoints     = dbOutpost.powerPoints,
+    .maxPowerPoints  = dbOutpost.maxPowerPoints,
+    .powerRegen      = dbOutpost.powerRegen,
+    .faction         = dbOutpost.faction,
+    .targetDbId      = targetDbId,
+  };
+}
+
+auto WeaponProps::toWeaponData() const -> WeaponData
+{
+  return WeaponData{
+    .dbId         = dbWeapon.id,
+    .weaponDbId   = dbWeapon.weapon,
+    .slotPosition = slotPosition,
+    .level        = dbWeapon.level,
+    .minDamage    = dbWeapon.minDamage,
+    .maxDamage    = dbWeapon.maxDamage,
+    .powerCost    = dbWeapon.powerCost,
+    .range        = dbWeapon.range,
+    .reloadTime   = dbWeapon.reloadTime,
+  };
+}
+
+auto toComputerData(const PlayerComputer &computer) -> ComputerData
+{
+  return ComputerData{
+    .dbId           = computer.id,
+    .computerDbId   = computer.computer,
+    .level          = computer.level,
+    .offensive      = computer.offensive,
+    .powerCost      = computer.powerCost,
+    .range          = computer.range,
+    .reloadTime     = computer.reloadTime,
+    .duration       = computer.duration,
+    .allowedTargets = computer.allowedTargets,
+    .damageModifier = computer.damageModifier,
+  };
+}
+
+auto ShipProps::toShipData() const -> ShipData
+{
+  ShipData data{
+    .dbId            = dbShip.id,
+    .position        = dbShip.position,
+    .radius          = dbShip.radius,
+    .acceleration    = dbShip.acceleration,
+    .speed           = dbShip.speed,
+    .hullPoints      = dbShip.hullPoints,
+    .maxHullPoints   = dbShip.maxHullPoints,
+    .hullPointsRegen = dbShip.hullPointsRegen,
+    .powerPoints     = dbShip.powerPoints,
+    .maxPowerPoints  = dbShip.maxPowerPoints,
+    .powerRegen      = dbShip.powerRegen,
+    .faction         = dbShip.faction,
+
+    .status           = status,
+    .shipClass        = dbShip.shipClass,
+    .name             = dbShip.name,
+    .docked           = dbShip.docked,
+    .jumpTime         = dbShip.jumpTime,
+    .jumpTimeInThreat = dbShip.jumpTimeInThreat,
+
+    .targetDbId = targetDbId,
+    .playerDbId = dbShip.player,
+  };
+
+  std::transform(weapons.begin(),
+                 weapons.end(),
+                 std::back_inserter(data.weapons),
+                 [](const WeaponProps &wp) { return wp.toWeaponData(); });
+
+  std::transform(computers.begin(),
+                 computers.end(),
+                 std::back_inserter(data.computers),
+                 [](const PlayerComputer &cp) { return toComputerData(cp); });
+
+  return data;
+}
+
+} // namespace bsgo

--- a/src/bsgo/services/LoadingServiceUtils.hh
+++ b/src/bsgo/services/LoadingServiceUtils.hh
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "AsteroidData.hh"
+#include "AsteroidRepository.hh"
+#include "Faction.hh"
+#include "OutpostData.hh"
+#include "PlayerComputerRepository.hh"
+#include "PlayerData.hh"
+#include "PlayerRepository.hh"
+#include "PlayerShipRepository.hh"
+#include "PlayerWeaponRepository.hh"
+#include "ShipData.hh"
+#include "Status.hh"
+#include "SystemOutpostRepository.hh"
+#include "Uuid.hh"
+
+namespace bsgo {
+
+auto toPlayerData(const Player &player) -> PlayerData;
+
+struct AsteroidProps
+{
+  Uuid dbId{};
+  Asteroid dbAsteroid{};
+
+  std::optional<Uuid> resource{};
+  std::optional<float> amount{};
+
+  auto toAsteroidData() const -> AsteroidData;
+};
+
+struct OutpostProps
+{
+  Uuid dbId{};
+  SystemOutpost dbOutpost{};
+  std::optional<Uuid> targetDbId{};
+
+  auto toOutpostData() const -> OutpostData;
+};
+
+struct WeaponProps
+{
+  PlayerWeapon dbWeapon{};
+  Eigen::Vector3f slotPosition{Eigen::Vector3f::Zero()};
+
+  auto toWeaponData() const -> WeaponData;
+};
+
+auto toComputerData(const PlayerComputer &computer) -> ComputerData;
+
+struct ShipProps
+{
+  PlayerShip dbShip{};
+  Status status{};
+  std::optional<Uuid> targetDbId{};
+  std::vector<WeaponProps> weapons{};
+  std::vector<PlayerComputer> computers{};
+
+  auto toShipData() const -> ShipData;
+};
+
+} // namespace bsgo

--- a/src/client/lib/consumers/ShipListMessageConsumer.cc
+++ b/src/client/lib/consumers/ShipListMessageConsumer.cc
@@ -25,7 +25,7 @@ void ShipListMessageConsumer::onMessageReceived(const bsgo::IMessage &message)
 void ShipListMessageConsumer::registerShip(const bsgo::ShipData &data) const
 {
   bsgo::ShipDataSource source;
-  source.registerShip(*m_coordinator, data, m_entityMapper, false);
+  source.registerShip(*m_coordinator, data, m_entityMapper, true);
 }
 
 } // namespace pge

--- a/src/client/lib/consumers/SystemMessageConsumer.cc
+++ b/src/client/lib/consumers/SystemMessageConsumer.cc
@@ -112,6 +112,9 @@ void SystemMessageConsumer::handleEntityRemoved(const bsgo::EntityRemovedMessage
       entityId = m_entityMapper.tryGetAsteroidEntityId(entityDbId);
       m_entityMapper.removeEntityForAsteroid(entityDbId);
       break;
+    case bsgo::EntityKind::PLAYER:
+      entityId = m_entityMapper.tryGetPlayerEntityId(entityDbId);
+      m_entityMapper.removeEntityForPlayer(entityDbId);
     default:
       break;
   }

--- a/src/client/lib/consumers/SystemMessageConsumer.cc
+++ b/src/client/lib/consumers/SystemMessageConsumer.cc
@@ -1,5 +1,6 @@
 
 #include "SystemMessageConsumer.hh"
+#include "AsteroidDataSource.hh"
 #include "MessageUtils.hh"
 
 namespace pge {
@@ -156,11 +157,8 @@ void SystemMessageConsumer::handleShipCreation(const bsgo::ShipData &data) const
 
 void SystemMessageConsumer::handleAsteroidCreation(const bsgo::AsteroidData &data) const
 {
-  if (!m_entityService->tryCreateAsteroidEntity(data.dbId))
-  {
-    warn("Failed to process asteroid added message for " + bsgo::str(data.dbId));
-    return;
-  }
+  bsgo::AsteroidDataSource source;
+  source.registerAsteroid(*m_coordinator, data, m_entityMapper);
 
   info("Registered entity for asteroid " + bsgo::str(data.dbId));
 }

--- a/src/client/lib/consumers/SystemMessageConsumer.cc
+++ b/src/client/lib/consumers/SystemMessageConsumer.cc
@@ -146,6 +146,7 @@ void SystemMessageConsumer::handleShipCreation(const bsgo::ShipData &data) const
     return;
   }
 
+  // TODO: This should be replaced by a call to the ShipDataSource
   if (!m_entityService->tryCreateShipEntity(data.dbId))
   {
     warn("Failed to process ship added message for " + bsgo::str(data.dbId));

--- a/src/client/lib/consumers/SystemMessageConsumer.hh
+++ b/src/client/lib/consumers/SystemMessageConsumer.hh
@@ -31,8 +31,8 @@ class SystemMessageConsumer : public bsgo::AbstractMessageConsumer
   void handleEntityAdded(const bsgo::EntityAddedMessage &message) const;
   void handleEntityRemoved(const bsgo::EntityRemovedMessage &message) const;
 
-  void handleShipCreation(const bsgo::Uuid shipDbId) const;
-  void handleAsteroidCreation(const bsgo::Uuid asteroidDbId) const;
+  void handleShipCreation(const bsgo::ShipData &data) const;
+  void handleAsteroidCreation(const bsgo::AsteroidData &data) const;
 };
 
 } // namespace pge

--- a/src/client/lib/consumers/SystemMessageConsumer.hh
+++ b/src/client/lib/consumers/SystemMessageConsumer.hh
@@ -33,6 +33,7 @@ class SystemMessageConsumer : public bsgo::AbstractMessageConsumer
 
   void handleShipCreation(const bsgo::ShipData &data) const;
   void handleAsteroidCreation(const bsgo::AsteroidData &data) const;
+  void handlePlayerCreation(const bsgo::PlayerData &data) const;
 };
 
 } // namespace pge

--- a/src/server/lib/consumers/internal/JumpMessageConsumer.cc
+++ b/src/server/lib/consumers/internal/JumpMessageConsumer.cc
@@ -84,14 +84,12 @@ void JumpMessageConsumer::handlePostJumpSystemMessages(const Uuid shipDbId,
   debug("Pushing removed message to " + str(sourceSystemDbId));
   sourceProcessor->pushMessage(std::move(removed));
 
-  // TODO: We should get the ship data and send the entity added message
-  // Or we just send the id and in the EntityAddedMessageConsumer we get
-  // the rest of it.
-  // auto added = std::make_unique<EntityAddedMessage>(shipDbId,
-  //                                                   EntityKind::SHIP,
-  //                                                   destinationSystemDbId);
-  // debug("Pushing added message to " + str(destinationSystemDbId));
-  // destinationProcessor->pushMessage(std::move(added));
+  auto added = std::make_unique<EntityAddedMessage>(destinationSystemDbId);
+  ShipData data{.dbId = shipDbId};
+  added->setShipData(data);
+
+  debug("Pushing added message to " + str(destinationSystemDbId));
+  destinationProcessor->pushMessage(std::move(added));
 }
 
 void JumpMessageConsumer::handleLoadingMessages(const Uuid playerDbId,

--- a/src/server/lib/consumers/internal/JumpMessageConsumer.cc
+++ b/src/server/lib/consumers/internal/JumpMessageConsumer.cc
@@ -84,11 +84,14 @@ void JumpMessageConsumer::handlePostJumpSystemMessages(const Uuid shipDbId,
   debug("Pushing removed message to " + str(sourceSystemDbId));
   sourceProcessor->pushMessage(std::move(removed));
 
-  auto added = std::make_unique<EntityAddedMessage>(shipDbId,
-                                                    EntityKind::SHIP,
-                                                    destinationSystemDbId);
-  debug("Pushing added message to " + str(destinationSystemDbId));
-  destinationProcessor->pushMessage(std::move(added));
+  // TODO: We should get the ship data and send the entity added message
+  // Or we just send the id and in the EntityAddedMessageConsumer we get
+  // the rest of it.
+  // auto added = std::make_unique<EntityAddedMessage>(shipDbId,
+  //                                                   EntityKind::SHIP,
+  //                                                   destinationSystemDbId);
+  // debug("Pushing added message to " + str(destinationSystemDbId));
+  // destinationProcessor->pushMessage(std::move(added));
 }
 
 void JumpMessageConsumer::handleLoadingMessages(const Uuid playerDbId,

--- a/src/server/lib/consumers/system/DockMessageConsumer.cc
+++ b/src/server/lib/consumers/system/DockMessageConsumer.cc
@@ -80,11 +80,11 @@ void DockMessageConsumer::handleUndocking(const DockMessage &message) const
   out->copyClientIdIfDefined(message);
   m_outputMessageQueue->pushMessage(std::move(out));
 
-  // TODO: We should get the ship data and send the entity added message
-  // Or we just send the id and in the EntityAddedMessageConsumer we get
-  // the rest of it.
-  // auto added = std::make_unique<EntityAddedMessage>(shipDbId, EntityKind::SHIP, systemDbId);
-  // m_outputMessageQueue->pushMessage(std::move(added));
+  auto added = std::make_unique<EntityAddedMessage>(systemDbId);
+  ShipData data{.dbId = shipDbId};
+  added->setShipData(data);
+
+  m_outputMessageQueue->pushMessage(std::move(added));
 
   auto started = std::make_unique<LoadingStartedMessage>(LoadingTransition::UNDOCK, systemDbId);
   started->copyClientIdIfDefined(message);

--- a/src/server/lib/consumers/system/DockMessageConsumer.cc
+++ b/src/server/lib/consumers/system/DockMessageConsumer.cc
@@ -80,8 +80,11 @@ void DockMessageConsumer::handleUndocking(const DockMessage &message) const
   out->copyClientIdIfDefined(message);
   m_outputMessageQueue->pushMessage(std::move(out));
 
-  auto added = std::make_unique<EntityAddedMessage>(shipDbId, EntityKind::SHIP, systemDbId);
-  m_outputMessageQueue->pushMessage(std::move(added));
+  // TODO: We should get the ship data and send the entity added message
+  // Or we just send the id and in the EntityAddedMessageConsumer we get
+  // the rest of it.
+  // auto added = std::make_unique<EntityAddedMessage>(shipDbId, EntityKind::SHIP, systemDbId);
+  // m_outputMessageQueue->pushMessage(std::move(added));
 
   auto started = std::make_unique<LoadingStartedMessage>(LoadingTransition::UNDOCK, systemDbId);
   started->copyClientIdIfDefined(message);

--- a/src/server/lib/consumers/system/DockMessageConsumer.cc
+++ b/src/server/lib/consumers/system/DockMessageConsumer.cc
@@ -69,12 +69,6 @@ void DockMessageConsumer::handleUndocking(const DockMessage &message) const
   const auto shipDbId   = message.getShipDbId();
   const auto systemDbId = message.getSystemDbId();
 
-  if (!m_entityService->tryCreateShipEntity(shipDbId))
-  {
-    warn("Failed to process undock message for ship " + str(shipDbId));
-    return;
-  }
-
   auto out = std::make_unique<DockMessage>(shipDbId, false, systemDbId);
   out->validate();
   out->copyClientIdIfDefined(message);
@@ -83,8 +77,7 @@ void DockMessageConsumer::handleUndocking(const DockMessage &message) const
   auto added = std::make_unique<EntityAddedMessage>(systemDbId);
   ShipData data{.dbId = shipDbId};
   added->setShipData(data);
-
-  m_outputMessageQueue->pushMessage(std::move(added));
+  m_systemMessageQueue->pushMessage(std::move(added));
 
   auto started = std::make_unique<LoadingStartedMessage>(LoadingTransition::UNDOCK, systemDbId);
   started->copyClientIdIfDefined(message);

--- a/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
+++ b/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
@@ -8,6 +8,7 @@ EntityAddedMessageConsumer::EntityAddedMessageConsumer(const Services &services,
                                                        IMessageQueue *const outputMessageQueue)
   : AbstractMessageConsumer("entity", {MessageType::ENTITY_ADDED})
   , m_entityService(services.entity)
+  , m_loadingService(services.loading)
   , m_outputMessageQueue(outputMessageQueue)
 {
   addModule("added");
@@ -15,6 +16,10 @@ EntityAddedMessageConsumer::EntityAddedMessageConsumer(const Services &services,
   if (nullptr == m_entityService)
   {
     throw std::invalid_argument("Expected non null entity service");
+  }
+  if (nullptr == m_loadingService)
+  {
+    throw std::invalid_argument("Expected non null loading service");
   }
   if (nullptr == m_outputMessageQueue)
   {

--- a/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
+++ b/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
@@ -46,15 +46,18 @@ void EntityAddedMessageConsumer::onMessageReceived(const IMessage &message)
 
 void EntityAddedMessageConsumer::handleShipAdded(const Uuid systemDbId, const ShipData &data) const
 {
-  // TODO: Verify if we need to pass the rest of the data
   if (!m_entityService->tryCreateShipEntity(data.dbId))
   {
     warn("Failed to process ship " + str(data.dbId) + " added in system " + str(systemDbId));
     return;
   }
 
+  // The input ship data is not complete. We need to get all of it from the
+  // loading service before sending the message to the client applications.
+  const auto shipData = m_loadingService->getShipById(data.dbId);
+
   auto out = std::make_unique<EntityAddedMessage>(systemDbId);
-  out->setShipData(data);
+  out->setShipData(shipData.toShipData());
   m_outputMessageQueue->pushMessage(std::move(out));
 }
 

--- a/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
+++ b/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
@@ -56,6 +56,8 @@ void EntityAddedMessageConsumer::handleShipAdded(const Uuid systemDbId, const Sh
   // loading service before sending the message to the client applications.
   const auto shipData = m_loadingService->getShipById(data.dbId);
 
+  // TODO: We should also send a EntityAddedMessage for the player
+
   auto out = std::make_unique<EntityAddedMessage>(systemDbId);
   out->setShipData(shipData.toShipData());
   m_outputMessageQueue->pushMessage(std::move(out));

--- a/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
+++ b/src/server/lib/consumers/system/EntityAddedMessageConsumer.cc
@@ -56,11 +56,21 @@ void EntityAddedMessageConsumer::handleShipAdded(const Uuid systemDbId, const Sh
   // loading service before sending the message to the client applications.
   const auto shipData = m_loadingService->getShipById(data.dbId);
 
-  // TODO: We should also send a EntityAddedMessage for the player
+  // In case the ship belongs to a player we also need to send a message to
+  // add this player to the system.
+  if (shipData.dbShip.player)
+  {
+    const auto playerData = m_loadingService->getPlayerById(*shipData.dbShip.player);
 
-  auto out = std::make_unique<EntityAddedMessage>(systemDbId);
-  out->setShipData(shipData.toShipData());
-  m_outputMessageQueue->pushMessage(std::move(out));
+    auto playerAdded = std::make_unique<EntityAddedMessage>(systemDbId);
+    PlayerData data{.dbId = playerData.id, .name = playerData.name};
+    playerAdded->setPlayerData(data);
+    m_outputMessageQueue->pushMessage(std::move(playerAdded));
+  }
+
+  auto shipAdded = std::make_unique<EntityAddedMessage>(systemDbId);
+  shipAdded->setShipData(shipData.toShipData());
+  m_outputMessageQueue->pushMessage(std::move(shipAdded));
 }
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/EntityAddedMessageConsumer.hh
+++ b/src/server/lib/consumers/system/EntityAddedMessageConsumer.hh
@@ -18,6 +18,7 @@ class EntityAddedMessageConsumer : public AbstractMessageConsumer
 
   private:
   EntityServiceShPtr m_entityService{};
+  LoadingServiceShPtr m_loadingService{};
   IMessageQueue *const m_outputMessageQueue{};
 
   void handleShipAdded(const Uuid systemDbId, const ShipData &data) const;

--- a/src/server/lib/consumers/system/EntityAddedMessageConsumer.hh
+++ b/src/server/lib/consumers/system/EntityAddedMessageConsumer.hh
@@ -4,6 +4,7 @@
 #include "AbstractMessageConsumer.hh"
 #include "IMessageQueue.hh"
 #include "Services.hh"
+#include "ShipData.hh"
 
 namespace bsgo {
 
@@ -19,7 +20,7 @@ class EntityAddedMessageConsumer : public AbstractMessageConsumer
   EntityServiceShPtr m_entityService{};
   IMessageQueue *const m_outputMessageQueue{};
 
-  void handleShipAdded(const Uuid shipDbId, const Uuid systemDbId) const;
+  void handleShipAdded(const Uuid systemDbId, const ShipData &data) const;
 };
 
 } // namespace bsgo

--- a/src/server/lib/consumers/system/EntityDeletedMessageConsumer.hh
+++ b/src/server/lib/consumers/system/EntityDeletedMessageConsumer.hh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "AbstractMessageConsumer.hh"
+#include "EntityRemovedMessage.hh"
 #include "IMessageQueue.hh"
 #include "Services.hh"
 
@@ -19,8 +20,8 @@ class EntityDeletedMessageConsumer : public AbstractMessageConsumer
   EntityServiceShPtr m_entityService{};
   IMessageQueue *const m_outputMessageQueue{};
 
-  void handleShipRemoved(const Uuid shipDbId) const;
-  void handleAsteroidRemoved(const Uuid asteroidDbId) const;
+  void handleShipRemoved(const EntityRemovedMessage &message) const;
+  void handleAsteroidRemoved(const EntityRemovedMessage &message) const;
 };
 
 } // namespace bsgo

--- a/tests/unit/bsgo/messages/EntityAddedMessageTest.cc
+++ b/tests/unit/bsgo/messages/EntityAddedMessageTest.cc
@@ -210,7 +210,33 @@ TEST(Unit_Bsgo_Serialization_EntityAddedMessage, OverrideOutpostData)
   assertMessagesAreEqual(actual, expected);
 }
 
-// TODO: Add tests for PlayerData
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, WithPlayerData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setPlayerData(PlayerData{.dbId = Uuid{123}, .name = "player1"});
+  expected.setClientId(Uuid{23});
+
+  EntityAddedMessage actual(Uuid{8564});
+  actual.setShipData(ShipData{.dbId = Uuid{36}, .powerPoints = 36.5f});
+
+  serializeAndDeserializeMessage(expected, actual);
+
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, OverridePlayerData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setPlayerData(PlayerData{.dbId = Uuid{123}, .name = "player1"});
+
+  EntityAddedMessage actual(Uuid{8564});
+  expected.setPlayerData(PlayerData{.dbId = Uuid{987}, .name = "player2"});
+  expected.setClientId(Uuid{47});
+
+  serializeAndDeserializeMessage(expected, actual);
+
+  assertMessagesAreEqual(actual, expected);
+}
 
 TEST(Unit_Bsgo_Serialization_EntityAddedMessage, CloneWithAsteroidData)
 {
@@ -243,6 +269,14 @@ TEST(Unit_Bsgo_Serialization_EntityAddedMessage, CloneWithOutpostData)
   assertMessagesAreEqual(cloned->as<EntityAddedMessage>(), expected);
 }
 
-// TODO: Add clone test for PlayerData
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, CloneWithPlayerData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setPlayerData(PlayerData{.dbId = Uuid{36}, .name = "my-player"});
+  const auto cloned = expected.clone();
+
+  ASSERT_EQ(cloned->type(), MessageType::ENTITY_ADDED);
+  assertMessagesAreEqual(cloned->as<EntityAddedMessage>(), expected);
+}
 
 } // namespace bsgo

--- a/tests/unit/bsgo/messages/EntityAddedMessageTest.cc
+++ b/tests/unit/bsgo/messages/EntityAddedMessageTest.cc
@@ -20,12 +20,14 @@ void assertMessagesAreEqual(const EntityAddedMessage &actual, const EntityAddedM
                                  expected.tryGetAsteroidData().value());
       EXPECT_FALSE(actual.tryGetShipData().has_value());
       EXPECT_FALSE(actual.tryGetOutpostData().has_value());
+      EXPECT_FALSE(actual.tryGetPlayerData().has_value());
       break;
 
     case EntityKind::SHIP:
       EXPECT_FALSE(actual.tryGetAsteroidData().has_value());
       assertShipDataAreEqual(actual.tryGetShipData().value(), expected.tryGetShipData().value());
       EXPECT_FALSE(actual.tryGetOutpostData().has_value());
+      EXPECT_FALSE(actual.tryGetPlayerData().has_value());
       break;
 
     case EntityKind::OUTPOST:
@@ -33,6 +35,15 @@ void assertMessagesAreEqual(const EntityAddedMessage &actual, const EntityAddedM
       EXPECT_FALSE(actual.tryGetShipData().has_value());
       assertOutpostDataAreEqual(actual.tryGetOutpostData().value(),
                                 expected.tryGetOutpostData().value());
+      EXPECT_FALSE(actual.tryGetPlayerData().has_value());
+      break;
+
+    case EntityKind::PLAYER:
+      EXPECT_FALSE(actual.tryGetAsteroidData().has_value());
+      EXPECT_FALSE(actual.tryGetShipData().has_value());
+      EXPECT_FALSE(actual.tryGetOutpostData().has_value());
+      assertPlayerDataAreEqual(actual.tryGetPlayerData().value(),
+                               expected.tryGetPlayerData().value());
       break;
 
     default:
@@ -78,6 +89,14 @@ TEST(Unit_Bsgo_Serialization_EntityAddedMessage, SetsEntityKindForOutpost)
     OutpostData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
 
   EXPECT_EQ(message.getEntityKind(), EntityKind::OUTPOST);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, SetsEntityKindForPlayer)
+{
+  EntityAddedMessage message(Uuid{789});
+  message.setPlayerData(PlayerData{.dbId = Uuid{123}, .name = "my-player"});
+
+  EXPECT_EQ(message.getEntityKind(), EntityKind::PLAYER);
 }
 
 TEST(Unit_Bsgo_Serialization_EntityAddedMessage, WhenAnotherKindOfDataIsSetExpectTypeToChange)
@@ -191,6 +210,8 @@ TEST(Unit_Bsgo_Serialization_EntityAddedMessage, OverrideOutpostData)
   assertMessagesAreEqual(actual, expected);
 }
 
+// TODO: Add tests for PlayerData
+
 TEST(Unit_Bsgo_Serialization_EntityAddedMessage, CloneWithAsteroidData)
 {
   EntityAddedMessage expected(Uuid{789});
@@ -221,5 +242,7 @@ TEST(Unit_Bsgo_Serialization_EntityAddedMessage, CloneWithOutpostData)
   ASSERT_EQ(cloned->type(), MessageType::ENTITY_ADDED);
   assertMessagesAreEqual(cloned->as<EntityAddedMessage>(), expected);
 }
+
+// TODO: Add clone test for PlayerData
 
 } // namespace bsgo

--- a/tests/unit/bsgo/messages/EntityAddedMessageTest.cc
+++ b/tests/unit/bsgo/messages/EntityAddedMessageTest.cc
@@ -7,38 +7,217 @@ using namespace ::testing;
 
 namespace bsgo {
 namespace {
-auto assertMessagesAreEqual(const EntityAddedMessage &actual, const EntityAddedMessage &expected)
+void assertMessagesAreEqual(const EntityAddedMessage &actual, const EntityAddedMessage &expected)
 {
   EXPECT_EQ(actual.type(), expected.type());
-  EXPECT_EQ(actual.getEntityDbId(), expected.getEntityDbId());
-  EXPECT_EQ(actual.getEntityKind(), expected.getEntityKind());
   EXPECT_EQ(actual.getSystemDbId(), expected.getSystemDbId());
   EXPECT_EQ(actual.tryGetClientId(), expected.tryGetClientId());
+
+  switch (actual.getEntityKind())
+  {
+    case EntityKind::ASTEROID:
+      assertAsteroidDataAreEqual(actual.tryGetAsteroidData().value(),
+                                 expected.tryGetAsteroidData().value());
+      EXPECT_FALSE(actual.tryGetShipData().has_value());
+      EXPECT_FALSE(actual.tryGetOutpostData().has_value());
+      break;
+
+    case EntityKind::SHIP:
+      EXPECT_FALSE(actual.tryGetAsteroidData().has_value());
+      assertShipDataAreEqual(actual.tryGetShipData().value(), expected.tryGetShipData().value());
+      EXPECT_FALSE(actual.tryGetOutpostData().has_value());
+      break;
+
+    case EntityKind::OUTPOST:
+      EXPECT_FALSE(actual.tryGetAsteroidData().has_value());
+      EXPECT_FALSE(actual.tryGetShipData().has_value());
+      assertOutpostDataAreEqual(actual.tryGetOutpostData().value(),
+                                expected.tryGetOutpostData().value());
+      break;
+
+    default:
+      FAIL() << "Unexpected entity kind: " << str(actual.getEntityKind());
+  }
 }
 } // namespace
 
-TEST(Unit_Bsgo_Serialization_EntityAddedMessage, Basic)
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, SerializationFailsWhenNoEntityKindIsSet)
 {
-  const EntityAddedMessage expected(Uuid{789}, EntityKind::ASTEROID, Uuid{123});
-  EntityAddedMessage actual(Uuid{10}, EntityKind::OUTPOST, Uuid{8564});
+  EntityAddedMessage message(Uuid{789});
+
+  EXPECT_THROW(
+    [&message] {
+      std::ostringstream out{};
+      message.serialize(out);
+    }(),
+    core::CoreException);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, SetsEntityKindForAsteroid)
+{
+  EntityAddedMessage message(Uuid{789});
+  message.setAsteroidData(
+    AsteroidData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
+
+  EXPECT_EQ(message.getEntityKind(), EntityKind::ASTEROID);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, SetsEntityKindForShip)
+{
+  EntityAddedMessage message(Uuid{789});
+  message.setShipData(
+    ShipData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
+
+  EXPECT_EQ(message.getEntityKind(), EntityKind::SHIP);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, SetsEntityKindForOutpost)
+{
+  EntityAddedMessage message(Uuid{789});
+  message.setOutpostData(
+    OutpostData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
+
+  EXPECT_EQ(message.getEntityKind(), EntityKind::OUTPOST);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, WhenAnotherKindOfDataIsSetExpectTypeToChange)
+{
+  EntityAddedMessage message(Uuid{789});
+  message.setAsteroidData(
+    AsteroidData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
+
+  EXPECT_EQ(message.getEntityKind(), EntityKind::ASTEROID);
+
+  message.setShipData(
+    ShipData{.dbId = Uuid{123}, .position = Eigen::Vector3f{3, 2, 1}, .radius = 4.5f});
+
+  EXPECT_EQ(message.getEntityKind(), EntityKind::SHIP);
+  EXPECT_FALSE(message.tryGetAsteroidData().has_value());
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, WithAsteroidData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setAsteroidData(
+    AsteroidData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
+
+  EntityAddedMessage actual(Uuid{8564});
+  actual.setOutpostData(OutpostData{.dbId = Uuid{36}, .hullPoints = 36.5f});
   actual.setClientId(Uuid{47});
+
   serializeAndDeserializeMessage(expected, actual);
+
   assertMessagesAreEqual(actual, expected);
 }
 
-TEST(Unit_Bsgo_Serialization_EntityAddedMessage, WithClientId)
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, OverrideAsteroidData)
 {
-  EntityAddedMessage expected(Uuid{789}, EntityKind::SHIP, Uuid{123});
-  expected.setClientId(Uuid{36});
-  EntityAddedMessage actual(Uuid{10}, EntityKind::BULLET, Uuid{7777});
+  EntityAddedMessage expected(Uuid{789});
+  expected.setAsteroidData(
+    AsteroidData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
+  expected.setClientId(Uuid{47});
+
+  EntityAddedMessage actual(Uuid{8564});
+  expected.setAsteroidData(AsteroidData{.dbId = Uuid{987}, .health = 1.597f});
+
   serializeAndDeserializeMessage(expected, actual);
+
   assertMessagesAreEqual(actual, expected);
 }
 
-TEST(Unit_Bsgo_Serialization_EntityAddedMessage, Clone)
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, WithShipData)
 {
-  EntityAddedMessage expected(Uuid{789}, EntityKind::ASTEROID, Uuid{123});
+  EntityAddedMessage expected(Uuid{789});
+  expected.setShipData(ShipData{.dbId     = Uuid{123},
+                                .position = Eigen::Vector3f{1, 2, 3},
+                                .radius   = 4.5f,
+                                .faction  = Faction::CYLON});
+  expected.setClientId(Uuid{23});
+
+  EntityAddedMessage actual(Uuid{8564});
+  actual.setAsteroidData(AsteroidData{.dbId = Uuid{36}, .health = 36.5f});
+  actual.setClientId(Uuid{47});
+
+  serializeAndDeserializeMessage(expected, actual);
+
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, OverrideShipData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setShipData(
+    ShipData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
+
+  EntityAddedMessage actual(Uuid{8564});
+  expected.setShipData(
+    ShipData{.dbId = Uuid{987}, .hullPointsRegen = 1.597f, .maxPowerPoints = 387.421f});
+
+  serializeAndDeserializeMessage(expected, actual);
+
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, WithOutpostData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setOutpostData(OutpostData{.dbId     = Uuid{123},
+                                      .position = Eigen::Vector3f{1, 2, 3},
+                                      .radius   = 4.5f,
+                                      .faction  = Faction::CYLON});
+  expected.setClientId(Uuid{23});
+
+  EntityAddedMessage actual(Uuid{8564});
+  actual.setAsteroidData(AsteroidData{.dbId = Uuid{36}, .health = 36.5f});
+  actual.setClientId(Uuid{47});
+
+  serializeAndDeserializeMessage(expected, actual);
+
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, OverrideOutpostData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setOutpostData(
+    OutpostData{.dbId = Uuid{123}, .position = Eigen::Vector3f{1, 2, 3}, .radius = 4.5f});
+
+  EntityAddedMessage actual(Uuid{8564});
+  expected.setOutpostData(
+    OutpostData{.dbId = Uuid{987}, .hullPointsRegen = 1.597f, .maxPowerPoints = 387.421f});
+
+  serializeAndDeserializeMessage(expected, actual);
+
+  assertMessagesAreEqual(actual, expected);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, CloneWithAsteroidData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setAsteroidData(AsteroidData{.dbId = Uuid{36}, .health = 36.5f});
   const auto cloned = expected.clone();
+
+  ASSERT_EQ(cloned->type(), MessageType::ENTITY_ADDED);
+  assertMessagesAreEqual(cloned->as<EntityAddedMessage>(), expected);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, CloneWithShipData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setShipData(ShipData{.dbId = Uuid{36}, .name = "my-ship"});
+  const auto cloned = expected.clone();
+
+  ASSERT_EQ(cloned->type(), MessageType::ENTITY_ADDED);
+  assertMessagesAreEqual(cloned->as<EntityAddedMessage>(), expected);
+}
+
+TEST(Unit_Bsgo_Serialization_EntityAddedMessage, CloneWithOutpostData)
+{
+  EntityAddedMessage expected(Uuid{789});
+  expected.setOutpostData(
+    OutpostData{.dbId = Uuid{36}, .powerRegen = 36.5f, .targetDbId = Uuid{987}});
+  const auto cloned = expected.clone();
+
   ASSERT_EQ(cloned->type(), MessageType::ENTITY_ADDED);
   assertMessagesAreEqual(cloned->as<EntityAddedMessage>(), expected);
 }


### PR DESCRIPTION
# Work

## Context

In #9 we decoupled loading the game data from the database when the user leaves the outpost. There are numerous other places where the client applications still accesses the database directly. One of those is when a `EntityAddedMessage` is received.

This PR refactors the way the `EntityAddedMessage` to not only communicate the database identifier of the entity that was added but rather the complete data needed to instantiate it.

## Implementation details

In #22 some dedicated `struct`s were added to describe the data needed by the client applications to register an entity of different kind (asteroid, ship, etc.).

We can reuse these `struct`s to communicate the data to be loaded in the `EntityAddedMessage`.

Additionally in the client application, the `SystemMessageConsumer` does not use the `EntityService` anymore (which accesses the database under the hood) but rather use the data in the message to create the entity through the data sources.

## How to route the `EntityAddedMessage`?

Until now the `EntityAddedMessage` was routed in two different ways based on the reason why it was produced:
* it was routed directly to the client application in case of a player leaving the outpost
* it was routed to the system processor when a player jumps to another system

To make it more consistent, it seems better to have a single flow to create an entity in a system. It naturally seems like a responsibility of the `SystemProcessor`. Based on this, this PR changes the undock case and makes it produce an `EntityAddedMessage` not directly sent to the clients' applications but rather to the system processor:

```diff
-  auto added = std::make_unique<EntityAddedMessage>(shipDbId, EntityKind::SHIP, systemDbId);
-  m_outputMessageQueue->pushMessage(std::move(added));
+  auto added = std::make_unique<EntityAddedMessage>(systemDbId);
+  ShipData data{.dbId = shipDbId};
+  added->setShipData(data);
+  m_systemMessageQueue->pushMessage(std::move(added));
```

## How to fill the `EntityAddedMessage` data?

The `EntityAddedMessage` now contains more information than before: namely it contains the full data of the entity to be created instead of just it's database identifier.

We already have a `LoadingService` able to get the information on entities in a system. The first step was to extend it to only return a single entity by identifier instead of all the ones existing in a system.

Additionally, we can leverage the changes explained in the previous section to streamline the process: we only need the data when actually creating the entity in the server and when loading it in the client. This means that the `JumpMessageConsumer` and the `DockMessageConsumer` can produce a half-filled message with only the database identifier of the entity to create: it is then up to the `EntityAddedMessageConsumer` to get the data from the `LoadingService` and fill the message before sending it to the clients applications.

## Changes to the docking/jumping strategy

There's a difference in how the client application gets informed about new ships entering the system depending on whether it's the ship of the player or some other ship.

For the ship of the player the process is as follows:
* upon clicking the undock button, the server will bounce back the validated dock message
* the loading process will start
* all players in the system (**including the ones that are still docked**) will be received
* only visible ships will be received

This means that there are players registered in the client application even though their ship is not visible.

When another player undocks/join a new system, we receive a `EntityAddedMessage` indicating that a new ship is there. This will:
* trigger the creation of the player if it does not exist yet
* trigger the creation of the ship

In case of a jump, the source system will **never delete the player**.

With the new approach where the `EntityAddedMessage` can have a type, we can make the process consistent by:
* removing the docked players from the loading messages
* when a player undocks, two `EntityAddedMessage`s are sent:
   * one for the creation of the player
   * one for the creation of the ship

This makes it easier to follow what's needed and make it transparent that we need both the player and the ship to correctly instantiate such an entity in the system.

Additionally, we also need to remove the player from the system when they jump out: this can be done by sending an additional `EntityRemovedMessage` with kind `PLAYER`. This is sent alongside the message for the deletion of the ship and can be interpreted in the clients' applications to delete the player entity.

# Tests

This PR:
* refactored the `ShipData`, `OutpostData`, etc. tests to rely on a common comparison code
* adapts and extends the tests suite for the `EntityAddedMessage` to cover new cases
* all other tests are still passing

Additionally we verified locally that:
* the game still loads correctly
* loading a new system also works
* a new player is getting added to the system and is visible for a player already in the system
* the player is deleted alongside the ship when jumping to another system

# Future work

With this change we can remove some of the public interface defined in `DataSource` as it's not used anymore by the client. This will make the loading cleaner and will be a first step in enabling the complete removal of the `DataSource` from the `Game` class.
