### PR TITLE
feat: Added de/serialization for tick

### DIFF
--- a/src/bsgo/CMakeLists.txt
+++ b/src/bsgo/CMakeLists.txt
@@ -51,6 +51,10 @@ add_subdirectory (
 	${CMAKE_CURRENT_SOURCE_DIR}/systems
 	)
 
+add_subdirectory (
+	${CMAKE_CURRENT_SOURCE_DIR}/time
+	)
+
 target_include_directories (bsgo_lib PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}
 	)

--- a/src/bsgo/time/CMakeLists.txt
+++ b/src/bsgo/time/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_sources (bsgo_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/Tick.cc
+	)
+
+target_include_directories (bsgo_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)

--- a/src/bsgo/time/Tick.cc
+++ b/src/bsgo/time/Tick.cc
@@ -1,9 +1,10 @@
 
 #include "Tick.hh"
+#include "SerializationUtils.hh"
 #include <cmath>
 #include <stdexcept>
 
-namespace chrono {
+namespace bsgo {
 namespace {
 auto cast(const float in) -> std::tuple<int, float>
 {
@@ -55,6 +56,23 @@ auto Tick::operator+=(const Tick &rhs) -> Tick &
   return *this;
 }
 
+auto Tick::serialize(std::ostream &out) const -> std::ostream &
+{
+  core::serialize(out, m_count);
+  core::serialize(out, m_frac);
+
+  return out;
+}
+
+bool Tick::deserialize(std::istream &in)
+{
+  bool ok{true};
+  ok &= core::deserialize(in, m_count);
+  ok &= core::deserialize(in, m_frac);
+
+  return ok;
+}
+
 void Tick::validate()
 {
   if (m_count < 0 || m_frac < 0.0f || m_frac >= 1.0f)
@@ -64,4 +82,16 @@ void Tick::validate()
   }
 }
 
-} // namespace chrono
+auto operator<<(std::ostream &out, const Tick &tick) -> std::ostream &
+{
+  tick.serialize(out);
+  return out;
+}
+
+auto operator>>(std::istream &in, Tick &tick) -> std::istream &
+{
+  tick.deserialize(in);
+  return in;
+}
+
+} // namespace bsgo

--- a/src/bsgo/time/Tick.hh
+++ b/src/bsgo/time/Tick.hh
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace chrono {
+namespace bsgo {
 
 class Tick
 {
@@ -20,6 +20,9 @@ class Tick
 
   auto operator+=(const Tick &rhs) -> Tick &;
 
+  auto serialize(std::ostream &out) const -> std::ostream &;
+  bool deserialize(std::istream &in);
+
   private:
   int m_count{0};
   float m_frac{0.0f};
@@ -27,4 +30,7 @@ class Tick
   void validate();
 };
 
-} // namespace chrono
+auto operator<<(std::ostream &out, const Tick &tick) -> std::ostream &;
+auto operator>>(std::istream &in, Tick &tick) -> std::istream &;
+
+} // namespace bsgo

--- a/src/server/lib/game/SystemProcessor.cc
+++ b/src/server/lib/game/SystemProcessor.cc
@@ -76,7 +76,7 @@ void SystemProcessor::stop()
 void SystemProcessor::initialize()
 {
   const chrono::TimeStep timeStep(1, chrono::Duration(chrono::Unit::MILLISECONDS, 100));
-  m_timeManager = std::make_unique<chrono::TimeManager>(chrono::Tick(), timeStep);
+  m_timeManager = std::make_unique<chrono::TimeManager>(Tick(), timeStep);
 }
 
 void SystemProcessor::asyncSystemProcessing()

--- a/src/time/CMakeLists.txt
+++ b/src/time/CMakeLists.txt
@@ -5,7 +5,6 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 target_sources (time_lib PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/Duration.cc
-	${CMAKE_CURRENT_SOURCE_DIR}/Tick.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/TimeManager.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/TimeStep.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/Unit.cc
@@ -18,6 +17,7 @@ target_include_directories (time_lib PUBLIC
 target_link_libraries (time_lib PUBLIC
 	bsgalone-interface-library
 	core_lib
+	bsgo_lib
 	)
 
 if (${ENABLE_TESTS})

--- a/src/time/TimeManager.cc
+++ b/src/time/TimeManager.cc
@@ -4,7 +4,7 @@
 
 namespace chrono {
 
-TimeManager::TimeManager(const Tick tick, const TimeStep step)
+TimeManager::TimeManager(const bsgo::Tick tick, const TimeStep step)
   : core::CoreObject("manager")
   , m_currentTick(tick)
   , m_step(step)
@@ -12,7 +12,7 @@ TimeManager::TimeManager(const Tick tick, const TimeStep step)
   setService("time");
 }
 
-auto TimeManager::tick(const Duration elapsed) -> Tick
+auto TimeManager::tick(const Duration elapsed) -> bsgo::Tick
 {
   const auto tick = m_step.count(elapsed);
   m_currentTick += tick;

--- a/src/time/TimeManager.hh
+++ b/src/time/TimeManager.hh
@@ -12,13 +12,13 @@ namespace chrono {
 class TimeManager : public core::CoreObject
 {
   public:
-  TimeManager(const Tick tick, const TimeStep step);
+  TimeManager(const bsgo::Tick tick, const TimeStep step);
   ~TimeManager() = default;
 
-  auto tick(const Duration elapsed) -> Tick;
+  auto tick(const Duration elapsed) -> bsgo::Tick;
 
   private:
-  Tick m_currentTick{};
+  bsgo::Tick m_currentTick{};
   TimeStep m_step{};
 };
 

--- a/src/time/TimeStep.cc
+++ b/src/time/TimeStep.cc
@@ -8,12 +8,12 @@ TimeStep::TimeStep(const int ticks, const Duration &inDuration)
   , m_duration(inDuration)
 {}
 
-auto TimeStep::count(const Duration &elapsed) const -> Tick
+auto TimeStep::count(const Duration &elapsed) const -> bsgo::Tick
 {
   const auto in     = elapsed.convert(m_duration.unit);
   const auto epochs = in.elapsed / static_cast<float>(m_duration.elapsed);
 
-  return Tick(epochs * static_cast<float>(m_ticks));
+  return bsgo::Tick(epochs * static_cast<float>(m_ticks));
 }
 
 } // namespace chrono

--- a/src/time/TimeStep.hh
+++ b/src/time/TimeStep.hh
@@ -13,7 +13,7 @@ class TimeStep
   TimeStep(const int ticks, const Duration &inDuration);
   ~TimeStep() = default;
 
-  auto count(const Duration &elapsed) const -> Tick;
+  auto count(const Duration &elapsed) const -> bsgo::Tick;
 
   private:
   int m_ticks{1};

--- a/tests/unit/bsgo/CMakeLists.txt
+++ b/tests/unit/bsgo/CMakeLists.txt
@@ -10,3 +10,7 @@ add_subdirectory(
 add_subdirectory(
 	${CMAKE_CURRENT_SOURCE_DIR}/messages
 	)
+
+add_subdirectory(
+	${CMAKE_CURRENT_SOURCE_DIR}/time
+	)

--- a/tests/unit/bsgo/time/CMakeLists.txt
+++ b/tests/unit/bsgo/time/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_include_directories(unitTests PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources(unitTests PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/TickTest.cc
+	)

--- a/tests/unit/bsgo/time/TickTest.cc
+++ b/tests/unit/bsgo/time/TickTest.cc
@@ -4,7 +4,7 @@
 
 using namespace ::testing;
 
-namespace chrono {
+namespace bsgo {
 namespace {
 constexpr auto TOLERANCE = 1e-4f;
 
@@ -15,12 +15,12 @@ void assertTickMatches(const Tick &tick, const int expectedInt, const float expe
 }
 } // namespace
 
-TEST(Unit_Chrono_Tick, CreatesValidDefaultTick)
+TEST(Unit_Bsgo_Tick, CreatesValidDefaultTick)
 {
   assertTickMatches(Tick(), 0, 0.0f);
 }
 
-TEST(Unit_Chrono_Tick, CreatesValidTickFromFloat)
+TEST(Unit_Bsgo_Tick, CreatesValidTickFromFloat)
 {
   assertTickMatches(Tick(0.147f), 0, 0.147f);
   assertTickMatches(Tick(1.0f), 1, 0.0f);
@@ -28,7 +28,7 @@ TEST(Unit_Chrono_Tick, CreatesValidTickFromFloat)
   assertTickMatches(Tick(2871.289f), 2871, 0.289f);
 }
 
-TEST(Unit_Chrono_Tick, CreatesValidTickFromIntAndFrac)
+TEST(Unit_Bsgo_Tick, CreatesValidTickFromIntAndFrac)
 {
   assertTickMatches(Tick(1, 0.0f), 1, 0.0f);
   assertTickMatches(Tick(0, 0.754f), 0, 0.754f);
@@ -36,17 +36,17 @@ TEST(Unit_Chrono_Tick, CreatesValidTickFromIntAndFrac)
   assertTickMatches(Tick(1971, 0.99f), 1971, 0.99f);
 }
 
-TEST(Unit_Chrono_Tick, ThrowsWhenIntIsNegative)
+TEST(Unit_Bsgo_Tick, ThrowsWhenIntIsNegative)
 {
   EXPECT_THROW([] { Tick(-1, 0.1f); }(), std::invalid_argument);
 }
 
-TEST(Unit_Chrono_Tick, ThrowsWhenFracIsNegative)
+TEST(Unit_Bsgo_Tick, ThrowsWhenFracIsNegative)
 {
   EXPECT_THROW([] { Tick(12, -0.1f); }(), std::invalid_argument);
 }
 
-TEST(Unit_Chrono_Tick, ThrowsWhenFracIsGreaterThanOne)
+TEST(Unit_Bsgo_Tick, ThrowsWhenFracIsGreaterThanOne)
 {
   EXPECT_THROW([] { Tick(12, 1.0f); }(), std::invalid_argument);
   EXPECT_THROW([] { Tick(12, 14.01f); }(), std::invalid_argument);
@@ -72,7 +72,7 @@ TEST_P(AdditionTest, AddsCorrectly)
   assertTickMatches(actual, param.expectedCount, param.expectedFrac);
 }
 
-INSTANTIATE_TEST_SUITE_P(Unit_Chrono_Tick,
+INSTANTIATE_TEST_SUITE_P(Unit_Bsgo_Tick,
                          AdditionTest,
                          Values(TestCaseTickAddition{.lhs           = Tick(0.0f),
                                                      .rhs           = Tick(0.0f),
@@ -118,4 +118,44 @@ INSTANTIATE_TEST_SUITE_P(Unit_Chrono_Tick,
                            return out;
                          });
 
-} // namespace chrono
+namespace {
+inline auto serializeAndDeserializeTick(const Tick &value, Tick &output)
+{
+  std::ostringstream out{};
+  out << value;
+  std::istringstream in(out.str());
+  in >> output;
+}
+} // namespace
+
+TEST(Unit_Bsgo_Tick, DefaultTick)
+{
+  const Tick expected;
+  Tick actual(1, 0.2f);
+
+  serializeAndDeserializeTick(expected, actual);
+
+  assertTickMatches(actual, expected.count(), expected.frac());
+}
+
+TEST(Unit_Bsgo_Tick, NonDefaultTick)
+{
+  const Tick expected(89, 0.579f);
+  Tick actual(17.3f);
+
+  serializeAndDeserializeTick(expected, actual);
+
+  assertTickMatches(actual, expected.count(), expected.frac());
+}
+
+TEST(Unit_Bsgo_Tick, FromFloat)
+{
+  const Tick expected(135.00235f);
+  Tick actual(31, 0.0042f);
+
+  serializeAndDeserializeTick(expected, actual);
+
+  assertTickMatches(actual, expected.count(), expected.frac());
+}
+
+} // namespace bsgo

--- a/tests/unit/time/CMakeLists.txt
+++ b/tests/unit/time/CMakeLists.txt
@@ -5,7 +5,6 @@ target_include_directories (unitTests PUBLIC
 
 target_sources (unitTests PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/DurationTest.cc
-	${CMAKE_CURRENT_SOURCE_DIR}/TickTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/TimeManagerTest.cc
 	${CMAKE_CURRENT_SOURCE_DIR}/TimeStepTest.cc
 	)

--- a/tests/unit/time/TimeManagerTest.cc
+++ b/tests/unit/time/TimeManagerTest.cc
@@ -9,10 +9,10 @@ namespace chrono {
 struct TestCaseTick
 {
   int id{};
-  Tick startTick{};
+  bsgo::Tick startTick{};
   TimeStep step{};
   Duration elapsed{};
-  Tick expectedTick{};
+  bsgo::Tick expectedTick{};
 };
 
 using TickTest = TestWithParam<TestCaseTick>;
@@ -34,24 +34,24 @@ INSTANTIATE_TEST_SUITE_P(Unit_Chrono_TimeManager,
                          Values(
                            TestCaseTick{
                              .id           = 0,
-                             .startTick    = Tick(),
+                             .startTick    = bsgo::Tick(),
                              .step         = TimeStep{},
                              .elapsed      = Duration{.unit = Unit::SECONDS, .elapsed = 1.0f},
-                             .expectedTick = Tick(10, 0.0f),
+                             .expectedTick = bsgo::Tick(10, 0.0f),
                            },
                            TestCaseTick{
                              .id        = 1,
-                             .startTick = Tick(),
+                             .startTick = bsgo::Tick(),
                              .step      = TimeStep{},
                              .elapsed   = Duration{.unit = Unit::MILLISECONDS, .elapsed = 1000.0f},
-                             .expectedTick = Tick(10, 0.0f),
+                             .expectedTick = bsgo::Tick(10, 0.0f),
                            },
                            TestCaseTick{
                              .id        = 2,
-                             .startTick = Tick(),
+                             .startTick = bsgo::Tick(),
                              .step      = TimeStep{},
                              .elapsed   = Duration{.unit = Unit::MILLISECONDS, .elapsed = 128.0f},
-                             .expectedTick = Tick(1, 0.28f),
+                             .expectedTick = bsgo::Tick(1, 0.28f),
                            }),
                          [](const TestParamInfo<TestCaseTick> &info) -> std::string {
                            return std::to_string(info.param.id);

--- a/tests/unit/time/TimeStepTest.cc
+++ b/tests/unit/time/TimeStepTest.cc
@@ -8,7 +8,7 @@ namespace chrono {
 namespace {
 constexpr auto TOLERANCE = 1e-4f;
 
-void assertTickMatches(const Tick &tick, const Tick expectedTick)
+void assertTickMatches(const bsgo::Tick &tick, const bsgo::Tick expectedTick)
 {
   EXPECT_EQ(tick.count(), expectedTick.count()) << "Tick is " << tick.str();
   EXPECT_NEAR(tick.frac(), expectedTick.frac(), TOLERANCE) << "Tick is " << tick.str();
@@ -21,7 +21,7 @@ struct TestCaseTimeStepCount
   int ticks{};
   Duration duration{};
   Duration input{};
-  Tick expectedTick{};
+  bsgo::Tick expectedTick{};
 };
 
 using CountTest = TestWithParam<TestCaseTimeStepCount>;
@@ -44,56 +44,56 @@ INSTANTIATE_TEST_SUITE_P(Unit_Chrono_TimeStep,
                              .ticks        = 1,
                              .duration     = Duration(Unit::MILLISECONDS, 100.0f),
                              .input        = Duration(Unit::MILLISECONDS, 100.0f),
-                             .expectedTick = Tick(1, 0.0f),
+                             .expectedTick = bsgo::Tick(1, 0.0f),
                            },
                            TestCaseTimeStepCount{
                              .id           = 1,
                              .ticks        = 2,
                              .duration     = Duration(Unit::MILLISECONDS, 100.0f),
                              .input        = Duration(Unit::MILLISECONDS, 100.0f),
-                             .expectedTick = Tick(2, 0.0f),
+                             .expectedTick = bsgo::Tick(2, 0.0f),
                            },
                            TestCaseTimeStepCount{
                              .id           = 2,
                              .ticks        = 1,
                              .duration     = Duration(Unit::MILLISECONDS, 200.0f),
                              .input        = Duration(Unit::MILLISECONDS, 100.0f),
-                             .expectedTick = Tick(0, 0.5f),
+                             .expectedTick = bsgo::Tick(0, 0.5f),
                            },
                            TestCaseTimeStepCount{
                              .id           = 3,
                              .ticks        = 2,
                              .duration     = Duration(Unit::SECONDS, 1.0f),
                              .input        = Duration(Unit::MILLISECONDS, 100.0f),
-                             .expectedTick = Tick(0, 0.2f),
+                             .expectedTick = bsgo::Tick(0, 0.2f),
                            },
                            TestCaseTimeStepCount{
                              .id           = 4,
                              .ticks        = 1,
                              .duration     = Duration(Unit::SECONDS, 2.0f),
                              .input        = Duration(Unit::MILLISECONDS, 100.0f),
-                             .expectedTick = Tick(0, 0.05f),
+                             .expectedTick = bsgo::Tick(0, 0.05f),
                            },
                            TestCaseTimeStepCount{
                              .id           = 5,
                              .ticks        = 2,
                              .duration     = Duration(Unit::SECONDS, 1.0f),
                              .input        = Duration(Unit::SECONDS, 25.0f),
-                             .expectedTick = Tick(50, 0.0f),
+                             .expectedTick = bsgo::Tick(50, 0.0f),
                            },
                            TestCaseTimeStepCount{
                              .id           = 6,
                              .ticks        = 1,
                              .duration     = Duration(Unit::MILLISECONDS, 100.0f),
                              .input        = Duration(Unit::MILLISECONDS, 250.0f),
-                             .expectedTick = Tick(2, 0.5f),
+                             .expectedTick = bsgo::Tick(2, 0.5f),
                            },
                            TestCaseTimeStepCount{
                              .id           = 7,
                              .ticks        = 1,
                              .duration     = Duration(Unit::SECONDS, 0.1f),
                              .input        = Duration(Unit::MILLISECONDS, 250.0f),
-                             .expectedTick = Tick(2, 0.5f),
+                             .expectedTick = bsgo::Tick(2, 0.5f),
                            }),
                          [](const TestParamInfo<TestCaseTimeStepCount> &info) -> std::string {
                            return std::to_string(info.param.id);


### PR DESCRIPTION
# Work

In #39 a new system to measure the passage of time was added to the server application. In this PR, this library is extended with de/serialization capabilities.

The goal is to make it possible for the server to send the tick information to the client applications so that they can stay in sync. Additionally, some of the game data will be represented using ticks (such as the jump time, etc.): therefore we have the need to communicate the `Tick` through the network.

Additionally, it turns out that we will need the `Tick` also for the game logic. This makes sense: the `Coordinator` needs to simulate the passage of game-time and therefore will work based on ticks. For this reason, the `Tick` class was moved to the BSGO library.

# Tests

Some unit tests were added to verify the behavior.

# Future work

We still need to follow the implementation plan outlined in #39 to replace real world time usage with ticks in the game.

