### PR TITLE
feat: Use ticks for time dependent values in ships

### DIFF
--- a/database/bsgo/migrations/100_seed_types.up.sql
+++ b/database/bsgo/migrations/100_seed_types.up.sql
@@ -12,7 +12,7 @@ INSERT INTO resource ("name") VALUES ('titane');
 INSERT INTO slot ("type") VALUES ('weapon');
 INSERT INTO slot ("type") VALUES ('computer');
 
-INSERT INTO ship_class ("name", "jump_time_ms", "jump_time_threat_ms")
+INSERT INTO ship_class ("name", "jump_time", "jump_time_threat")
   VALUES ('strike', 5000, 60000);
-INSERT INTO ship_class ("name", "jump_time_ms", "jump_time_threat_ms")
+INSERT INTO ship_class ("name", "jump_time", "jump_time_threat")
   VALUES ('line', 25000, 100000);

--- a/database/bsgo/migrations/4_create_ships.up.sql
+++ b/database/bsgo/migrations/4_create_ships.up.sql
@@ -1,8 +1,8 @@
 
 CREATE TABLE ship_class (
   name TEXT NOT NULL,
-  jump_time_ms INTEGER NOT NULL,
-  jump_time_threat_ms INTEGER NOT NULL,
+  jump_time INTEGER NOT NULL,
+  jump_time_threat INTEGER NOT NULL,
   PRIMARY KEY (name)
 );
 

--- a/src/bsgo/data/PlayerShipData.hh
+++ b/src/bsgo/data/PlayerShipData.hh
@@ -6,7 +6,7 @@
 #include "PlayerWeaponData.hh"
 #include "ShipClass.hh"
 #include "Status.hh"
-#include "TimeUtils.hh"
+#include "Tick.hh"
 #include "Uuid.hh"
 #include <eigen3/Eigen/Eigen>
 #include <optional>
@@ -33,8 +33,8 @@ struct PlayerShipData
   std::string name{};
   bool docked{};
   bool active{};
-  core::Duration jumpTime{};
-  core::Duration jumpTimeInThreat{};
+  Tick jumpTime{};
+  Tick jumpTimeInThreat{};
   std::optional<Uuid> jumpSystem{};
 
   std::optional<Uuid> targetDbId{};

--- a/src/bsgo/data/ShipData.hh
+++ b/src/bsgo/data/ShipData.hh
@@ -5,7 +5,7 @@
 #include "ShipClass.hh"
 #include "ShipPriceRepository.hh"
 #include "ShipRepository.hh"
-#include "TimeUtils.hh"
+#include "Tick.hh"
 #include "Uuid.hh"
 #include <eigen3/Eigen/Eigen>
 #include <optional>
@@ -28,8 +28,8 @@ struct ShipData
   float speed{};
   float radius{};
 
-  core::Duration jumpTime{};
-  core::Duration jumpTimeInThreat{};
+  Tick jumpTime{};
+  Tick jumpTimeInThreat{};
 
   std::unordered_map<Slot, int> slots{};
   std::unordered_map<Uuid, int> price{};

--- a/src/bsgo/data/ShipDataSource.cc
+++ b/src/bsgo/data/ShipDataSource.cc
@@ -67,7 +67,10 @@ void ShipDataSource::registerShip(Coordinator &coordinator,
   coordinator.addHealth(shipEntityId, data.hullPoints, data.maxHullPoints, data.hullPointsRegen);
   coordinator.addPower(shipEntityId, data.powerPoints, data.maxPowerPoints, data.powerRegen);
   coordinator.addFaction(shipEntityId, data.faction);
-  coordinator.addStatus(shipEntityId, data.status, data.jumpTime, data.jumpTimeInThreat);
+  // TODO: Replace this to not convert back to a time.
+  const auto jumpTime         = core::toMilliseconds(data.jumpTime.count());
+  const auto jumpTimeInThreat = core::toMilliseconds(data.jumpTimeInThreat.count());
+  coordinator.addStatus(shipEntityId, data.status, jumpTime, jumpTimeInThreat);
   coordinator.addShipClass(shipEntityId, data.shipClass);
   coordinator.addName(shipEntityId, data.name);
   if (data.targetDbId)

--- a/src/bsgo/repositories/PlayerShipRepository.cc
+++ b/src/bsgo/repositories/PlayerShipRepository.cc
@@ -36,8 +36,8 @@ SELECT
   ps.z_pos,
   ss.system,
   ss.docked,
-  sc.jump_time_ms,
-  sc.jump_time_threat_ms,
+  sc.jump_time,
+  sc.jump_time_threat,
   sj.system
 FROM
   player_ship AS ps
@@ -289,8 +289,8 @@ auto PlayerShipRepository::fetchShipBase(const Uuid ship) const -> PlayerShip
     out.docked = record[19].as<bool>();
   }
 
-  out.jumpTime         = core::Milliseconds(record[20].as<int>());
-  out.jumpTimeInThreat = core::Milliseconds(record[21].as<int>());
+  out.jumpTime         = Tick::fromInt(record[20].as<int>());
+  out.jumpTimeInThreat = Tick::fromInt(record[21].as<int>());
   if (!record[22].is_null())
   {
     out.jumpSystem = fromDbId(record[22].as<int>());

--- a/src/bsgo/repositories/PlayerShipRepository.hh
+++ b/src/bsgo/repositories/PlayerShipRepository.hh
@@ -5,7 +5,7 @@
 #include "Faction.hh"
 #include "ShipClass.hh"
 #include "Slot.hh"
-#include "TimeUtils.hh"
+#include "Tick.hh"
 #include "Uuid.hh"
 #include <eigen3/Eigen/Eigen>
 #include <memory>
@@ -42,8 +42,8 @@ struct PlayerShip
   std::optional<Uuid> system{};
   bool docked{};
 
-  core::Duration jumpTime{};
-  core::Duration jumpTimeInThreat{};
+  Tick jumpTime{};
+  Tick jumpTimeInThreat{};
   std::optional<Uuid> jumpSystem{};
 
   std::unordered_map<Slot, int> slots{};

--- a/src/bsgo/repositories/ShipRepository.cc
+++ b/src/bsgo/repositories/ShipRepository.cc
@@ -9,12 +9,50 @@ ShipRepository::ShipRepository(const DbConnectionShPtr &connection)
 
 namespace {
 constexpr auto FIND_ONE_QUERY_NAME = "ship_find_one";
-constexpr auto FIND_ONE_QUERY
-  = "SELECT s.id, s.faction, s.class, s.name, s.max_hull_points, s.hull_points_regen, s.max_power_points, s.power_points_regen, s.max_acceleration, s.max_speed, s.radius, sc.jump_time_ms, sc.jump_time_threat_ms FROM ship AS s LEFT JOIN ship_class AS sc ON s.class = sc.name WHERE s.id = $1";
+constexpr auto FIND_ONE_QUERY      = R"(
+SELECT
+  s.id,
+  s.faction,
+  s.class,
+  s.name,
+  s.max_hull_points,
+  s.hull_points_regen,
+  s.max_power_points,
+  s.power_points_regen,
+  s.max_acceleration,
+  s.max_speed,
+  s.radius,
+  sc.jump_time,
+  sc.jump_time_threat
+FROM
+  ship AS s
+  LEFT JOIN ship_class AS sc ON s.class = sc.name
+WHERE
+  s.id = $1
+)";
 
 constexpr auto FIND_ALL_BY_FACTION_QUERY_NAME = "ship_find_all_by_faction";
-constexpr auto FIND_ALL_BY_FACTION_QUERY
-  = "SELECT s.id, s.faction, s.class, s.name, s.max_hull_points, s.hull_points_regen, s.max_power_points, s.power_points_regen, s.max_acceleration, s.max_speed, s.radius, sc.jump_time_ms, sc.jump_time_threat_ms FROM ship AS s LEFT JOIN ship_class AS sc ON s.class = sc.name WHERE s.faction = $1";
+constexpr auto FIND_ALL_BY_FACTION_QUERY      = R"(
+SELECT
+  s.id,
+  s.faction,
+  s.class,
+  s.name,
+  s.max_hull_points,
+  s.hull_points_regen,
+  s.max_power_points,
+  s.power_points_regen,
+  s.max_acceleration,
+  s.max_speed,
+  s.radius,
+  sc.jump_time,
+  sc.jump_time_threat
+FROM
+  ship AS s
+  LEFT JOIN ship_class AS sc ON s.class = sc.name
+WHERE
+  s.faction = $1
+)";
 
 constexpr auto FIND_SLOTS_QUERY_NAME = "ship_find_slots";
 constexpr auto FIND_SLOTS_QUERY
@@ -57,8 +95,8 @@ auto fetchShipFromSqlResult(const pqxx::const_result_iterator &record) -> Ship
   ship.acceleration     = record[8].as<float>();
   ship.speed            = record[9].as<float>();
   ship.radius           = record[10].as<float>();
-  ship.jumpTime         = core::Milliseconds(record[11].as<int>());
-  ship.jumpTimeInThreat = core::Milliseconds(record[12].as<int>());
+  ship.jumpTime         = Tick::fromInt(record[11].as<int>());
+  ship.jumpTimeInThreat = Tick::fromInt(record[12].as<int>());
 
   return ship;
 }

--- a/src/bsgo/repositories/ShipRepository.hh
+++ b/src/bsgo/repositories/ShipRepository.hh
@@ -5,7 +5,7 @@
 #include "Faction.hh"
 #include "ShipClass.hh"
 #include "Slot.hh"
-#include "TimeUtils.hh"
+#include "Tick.hh"
 #include "Uuid.hh"
 #include <memory>
 
@@ -29,8 +29,8 @@ struct Ship
 
   float radius{0.5f};
 
-  core::Duration jumpTime{};
-  core::Duration jumpTimeInThreat{};
+  Tick jumpTime{};
+  Tick jumpTimeInThreat{};
 
   std::unordered_map<Slot, int> slots{};
 };

--- a/src/bsgo/time/Tick.cc
+++ b/src/bsgo/time/Tick.cc
@@ -73,6 +73,11 @@ bool Tick::deserialize(std::istream &in)
   return ok;
 }
 
+auto Tick::fromInt(const int duration) -> Tick
+{
+  return Tick(duration, 0.0f);
+}
+
 void Tick::validate()
 {
   if (m_count < 0 || m_frac < 0.0f || m_frac >= 1.0f)

--- a/src/bsgo/time/Tick.hh
+++ b/src/bsgo/time/Tick.hh
@@ -23,6 +23,8 @@ class Tick
   auto serialize(std::ostream &out) const -> std::ostream &;
   bool deserialize(std::istream &in);
 
+  static auto fromInt(const int duration) -> Tick;
+
   private:
   int m_count{0};
   float m_frac{0.0f};

--- a/src/server/lib/consumers/system/LoadingMessagesConsumer.cc
+++ b/src/server/lib/consumers/system/LoadingMessagesConsumer.cc
@@ -401,10 +401,6 @@ void LoadingMessagesConsumer::handleSystemAsteroidsLoading(const LoadingStartedM
 {
   const auto systemDbId = message.getSystemDbId();
 
-  // TODO: Here and for ships, computers, etc.: as we fetch the data from the database
-  // this is not accurate. For example the status, health, power from individual entities
-  // might differ in the system processors than in the database.
-  // To fix it we would need to correctly propagate the changes to the database.
   const auto asteroids = m_loadingService->getAsteroidsInSystem(systemDbId);
 
   std::vector<AsteroidData> asteroidsData{};

--- a/tests/unit/bsgo/messages/Common.cc
+++ b/tests/unit/bsgo/messages/Common.cc
@@ -86,8 +86,12 @@ void assertPlayerShipDataAreEqual(const PlayerShipData &actual, const PlayerShip
   EXPECT_EQ(actual.name, expected.name);
   EXPECT_EQ(actual.docked, expected.docked);
   EXPECT_EQ(actual.active, expected.active);
-  EXPECT_EQ(actual.jumpTime, expected.jumpTime);
-  EXPECT_EQ(actual.jumpTimeInThreat, expected.jumpTimeInThreat);
+
+  EXPECT_EQ(actual.jumpTime.count(), expected.jumpTime.count());
+  EXPECT_EQ(actual.jumpTime.frac(), expected.jumpTime.frac());
+  EXPECT_EQ(actual.jumpTimeInThreat.count(), expected.jumpTimeInThreat.count());
+  EXPECT_EQ(actual.jumpTimeInThreat.frac(), expected.jumpTimeInThreat.frac());
+
   EXPECT_EQ(actual.jumpSystem, expected.jumpSystem);
   EXPECT_EQ(actual.targetDbId, expected.targetDbId);
   EXPECT_EQ(actual.playerDbId, expected.playerDbId);
@@ -177,8 +181,10 @@ void assertShipDataAreEqual(const ShipData &actual, const ShipData &expected)
   EXPECT_EQ(actual.speed, expected.speed);
   EXPECT_EQ(actual.radius, expected.radius);
 
-  EXPECT_EQ(actual.jumpTime, expected.jumpTime);
-  EXPECT_EQ(actual.jumpTimeInThreat, expected.jumpTimeInThreat);
+  EXPECT_EQ(actual.jumpTime.count(), expected.jumpTime.count());
+  EXPECT_EQ(actual.jumpTime.frac(), expected.jumpTime.frac());
+  EXPECT_EQ(actual.jumpTimeInThreat.count(), expected.jumpTimeInThreat.count());
+  EXPECT_EQ(actual.jumpTimeInThreat.frac(), expected.jumpTimeInThreat.frac());
 
   EXPECT_EQ(actual.slots, expected.slots);
   EXPECT_EQ(actual.price, expected.price);

--- a/tests/unit/bsgo/messages/HangarMessageTest.cc
+++ b/tests/unit/bsgo/messages/HangarMessageTest.cc
@@ -34,7 +34,7 @@ TEST(Unit_Bsgo_Serialization_HangarMessage, WithShip)
     data{.dbId             = Uuid{8},
          .radius           = 1.478f,
          .hullPoints       = 98.54f,
-         .jumpTimeInThreat = core::toMilliseconds(45001),
+         .jumpTimeInThreat = Tick(45001.0f),
          .weapons          = {{
                                 .dbId       = Uuid{2},
                                 .weaponDbId = Uuid{65},
@@ -67,9 +67,7 @@ TEST(Unit_Bsgo_Serialization_HangarMessage, WithShip)
 
 TEST(Unit_Bsgo_Serialization_HangarMessage, ShipIdIsEqualToShipData)
 {
-  const PlayerShipData data{.dbId     = Uuid{42},
-                            .docked   = true,
-                            .jumpTime = core::toMilliseconds(4587)};
+  const PlayerShipData data{.dbId = Uuid{42}, .docked = true, .jumpTime = Tick(4587.001f)};
   const HangarMessage message(data);
 
   EXPECT_EQ(message.getShipDbId(), data.dbId);
@@ -84,7 +82,7 @@ TEST(Unit_Bsgo_Serialization_HangarMessage, OverridesShipProperties)
     data{.dbId             = Uuid{8},
          .radius           = 1.478f,
          .hullPoints       = 98.54f,
-         .jumpTimeInThreat = core::toMilliseconds(45001),
+         .jumpTimeInThreat = Tick(45001, 0.7f),
          .weapons          = {{
                                 .dbId       = Uuid{2},
                                 .weaponDbId = Uuid{65},

--- a/tests/unit/bsgo/messages/loading/PlayerShipDataTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerShipDataTest.cc
@@ -125,8 +125,8 @@ TEST(Unit_Bsgo_Serialization_PlayerShipData, WithWeapons)
                        .position         = Eigen::Vector3f{1.0f, 2.0f, 3.0f},
                        .radius           = 5.0f,
                        .maxPowerPoints   = 100.0f,
-                       .jumpTime         = core::toMilliseconds(1234),
-                       .jumpTimeInThreat = core::toMilliseconds(5678),
+                       .jumpTime         = Tick(1234.2f),
+                       .jumpTimeInThreat = Tick(5678, 0.4f),
                        .targetDbId       = Uuid{8901},
                        .playerDbId       = Uuid{6547}};
   input.weapons.push_back({
@@ -173,8 +173,8 @@ TEST(Unit_Bsgo_Serialization_PlayerShipData, ClearsWeapons)
     .dbId             = Uuid{14},
     .faction          = Faction::CYLON,
     .status           = Status::JUMP,
-    .jumpTime         = core::toMilliseconds(75),
-    .jumpTimeInThreat = core::toMilliseconds(5678),
+    .jumpTime         = Tick(75, 0.01f),
+    .jumpTimeInThreat = Tick(5678, 0.978f),
   };
   output.weapons.push_back({.dbId       = Uuid{1001},
                             .weaponDbId = Uuid{2002},

--- a/tests/unit/bsgo/messages/loading/PlayerShipListMessageTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerShipListMessageTest.cc
@@ -181,7 +181,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, WithWeapon)
                                          .position         = Eigen::Vector3f(1.0f, 2.8f, 3.9f),
                                          .radius           = 26.9f,
                                          .hullPoints       = 12.34f,
-                                         .jumpTimeInThreat = core::toMilliseconds(5678),
+                                         .jumpTimeInThreat = Tick(5678.01f),
                                          .slots   = {{Slot::WEAPON, 3}, {Slot::COMPUTER, 2}},
                                          .weapons = weapons}};
 
@@ -216,7 +216,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, WithComputer)
                                          .position   = Eigen::Vector3f(1.0f, 2.8f, 3.9f),
                                          .radius     = 26.9f,
                                          .hullPoints = 12.34f,
-                                         .jumpTime   = core::toMilliseconds(75),
+                                         .jumpTime   = Tick(75, 0.9804f),
                                          .computers  = computers}};
 
   PlayerShipListMessage expected(shipsData);
@@ -263,8 +263,8 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, MultipleComplexShips)
      .position         = Eigen::Vector3f(1.2f, 3.4f, 4.5f),
      .radius           = 987.9f,
      .hullPoints       = 98.76f,
-     .jumpTime         = core::toMilliseconds(741),
-     .jumpTimeInThreat = core::toMilliseconds(369),
+     .jumpTime         = Tick(741, 0.24f),
+     .jumpTimeInThreat = Tick(369.09f),
      .slots            = {{Slot::COMPUTER, 5}},
      .weapons
      = {{.dbId = Uuid{16}, .weaponDbId = Uuid{14}, .level = 9, .range = 6.897f},
@@ -285,7 +285,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, MultipleComplexShips)
     = {{
          .dbId     = Uuid{7412},
          .position = Eigen::Vector3f(1.0f, 2.8f, 3.9f),
-         .jumpTime = core::toMilliseconds(785),
+         .jumpTime = Tick(785, 0.174f),
        },
        {.dbId = Uuid{7413}, .position = Eigen::Vector3f(98.76f, 54.32f, 1.09f)},
        {
@@ -306,10 +306,10 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, MultipleComplexShips)
                       {.computerDbId = 58, .damageModifier = 963.147f}}},
        {.dbId             = Uuid{7416},
         .docked           = true,
-        .jumpTimeInThreat = core::toMilliseconds(5678),
+        .jumpTimeInThreat = Tick(5678.098f),
         .jumpSystem       = Uuid{7932},
         .weapons          = {
-          {.weaponDbId = Uuid{852}, .name = "my weapon", .reloadTime = core::toMilliseconds(963)}}}};
+                   {.weaponDbId = Uuid{852}, .name = "my weapon", .reloadTime = core::toMilliseconds(963)}}}};
   PlayerShipListMessage actual(shipsData);
   actual.setSystemDbId(Uuid{3331});
   actual.setPlayerDbId(Uuid{745});

--- a/tests/unit/bsgo/messages/loading/ShipDataTest.cc
+++ b/tests/unit/bsgo/messages/loading/ShipDataTest.cc
@@ -33,7 +33,7 @@ TEST(Unit_Bsgo_Serialization_ShipData, DifferentWhenDbIdIsDifferent)
   ShipData data1{.dbId      = Uuid{1234},
                  .shipClass = ShipClass::STRIKE,
                  .radius    = 5.0f,
-                 .jumpTime  = core::toMilliseconds(529),
+                 .jumpTime  = Tick(529.0f),
                  .slots     = {{Slot::COMPUTER, 2}}};
 
   ShipData data2 = data1;
@@ -56,7 +56,7 @@ TEST(Unit_Bsgo_Serialization_ShipData, Basic)
                   .shipClass        = ShipClass::LINE,
                   .maxPowerPoints   = 78.954f,
                   .powerRegen       = 1.2345f,
-                  .jumpTimeInThreat = core::toMilliseconds(1234)};
+                  .jumpTimeInThreat = Tick(1234, 0.238f)};
 
   EXPECT_TRUE(serializeAndDeserializeMessage(input, output));
 

--- a/tests/unit/bsgo/messages/loading/ShipListMessageTest.cc
+++ b/tests/unit/bsgo/messages/loading/ShipListMessageTest.cc
@@ -37,7 +37,7 @@ TEST(Unit_Bsgo_Serialization_ShipListMessage, Basic)
                                         {.dbId             = Uuid{76},
                                          .maxHullPoints    = 100.0f,
                                          .hullPointsRegen  = 26.9f,
-                                         .jumpTimeInThreat = core::toMilliseconds(1265)}};
+                                         .jumpTimeInThreat = Tick(1265.89f)}};
   ShipListMessage actual(Faction::COLONIAL, shipsData);
   actual.setClientId(Uuid{2});
 
@@ -52,7 +52,7 @@ TEST(Unit_Bsgo_Serialization_ShipListMessage, WithClientId)
                                    .shipClass       = ShipClass::LINE,
                                    .hullPointsRegen = 12.34f,
                                    .maxPowerPoints  = 56.78f,
-                                   .jumpTime        = core::toMilliseconds(7456),
+                                   .jumpTime        = Tick(7456.10f),
                                    .slots           = {{Slot::COMPUTER, 2}, {Slot::WEAPON, 3}}}};
 
   ShipListMessage expected(Faction::COLONIAL, shipsData);
@@ -79,7 +79,7 @@ TEST(Unit_Bsgo_Serialization_ShipListMessage, Clone)
      .shipClass        = ShipClass::STRIKE,
      .name             = "another ship",
      .acceleration     = 1.257f,
-     .jumpTimeInThreat = core::toMilliseconds(3224),
+     .jumpTimeInThreat = Tick(3224, 0.08f),
      .slots            = {{Slot::WEAPON, 14}}},
   };
 
@@ -103,12 +103,12 @@ TEST(Unit_Bsgo_Serialization_ShipListMessage, MultipleComplexShips)
      .acceleration   = 17.45f,
      .speed          = 23.65f,
      .radius         = 1.02f,
-     .jumpTime       = core::toMilliseconds(5412)},
+     .jumpTime       = Tick(5412, 0.9007f)},
     {
       .dbId             = Uuid{68},
       .hullPointsRegen  = 98.76f,
-      .jumpTime         = core::toMilliseconds(741),
-      .jumpTimeInThreat = core::toMilliseconds(369),
+      .jumpTime         = Tick(741.01f),
+      .jumpTimeInThreat = Tick(369, 0.502f),
       .slots            = {{Slot::COMPUTER, 5}},
     },
   };
@@ -119,12 +119,12 @@ TEST(Unit_Bsgo_Serialization_ShipListMessage, MultipleComplexShips)
      .shipClass     = ShipClass::STRIKE,
      .maxHullPoints = 14.47f,
      .radius        = 1.02f,
-     .jumpTime      = core::toMilliseconds(5412)},
+     .jumpTime      = Tick(5412.57f)},
     {.dbId             = Uuid{45},
      .shipClass        = ShipClass::LINE,
      .maxPowerPoints   = 21.74f,
      .acceleration     = 14.32f,
-     .jumpTimeInThreat = core::toMilliseconds(3789)},
+     .jumpTimeInThreat = Tick(3789, 0.14f)},
     {.dbId      = Uuid{41},
      .shipClass = ShipClass::STRIKE,
      .name      = "the mosquito",

--- a/tests/unit/bsgo/time/TickTest.cc
+++ b/tests/unit/bsgo/time/TickTest.cc
@@ -158,4 +158,13 @@ TEST(Unit_Bsgo_Tick, FromFloat)
   assertTickMatches(actual, expected.count(), expected.frac());
 }
 
+TEST(Unit_Bsgo_Tick, FromInt)
+{
+  assertTickMatches(Tick::fromInt(31), 31, 0.0f);
+  assertTickMatches(Tick::fromInt(14), 14, 0.0f);
+  assertTickMatches(Tick::fromInt(0), 0, 0.0f);
+  assertTickMatches(Tick::fromInt(1), 1, 0.0f);
+  assertTickMatches(Tick::fromInt(17), 17, 0.0f);
+}
+
 } // namespace bsgo


### PR DESCRIPTION
# Work

In #39 a library to manage time in a way that is not dependent of the real time simulation speed. This library allows to decouple the effects that rely on time (e.g. reload time, jump time, etc.) from real time.

Currently there are a couple of values that rely on time for ships such as the jump time. This PR decouples this by replacing the values in milliseconds and having them expressed in ticks.

# Tests

It was verified locally that the jump time both in threat and without threat still match the old values.

# Future work

The core simulation logic still relies on time. The reason for this is that there are other values that are still provided in milli/seconds: this includes for example the reload time and the duration of the effect.

When those are also changed to use tick it will be possible to replace the logic in the `Coordinator` to use ticks as well.
