### PR TITLE
feat: Used Tick as time unit for player weapons and computers

### DIFF
--- a/src/bsgo/components/ComputerSlotComponent.cc
+++ b/src/bsgo/components/ComputerSlotComponent.cc
@@ -5,15 +5,21 @@ namespace bsgo {
 
 ComputerSlotComponent::ComputerSlotComponent(const PlayerComputerData &computer)
   : SlotComponent(ComponentType::COMPUTER_SLOT,
-                  SlotComponentData{.dbId       = computer.dbId,
-                                    .offensive  = computer.offensive,
-                                    .powerCost  = computer.powerCost,
-                                    .range      = computer.range,
-                                    .reloadTime = computer.reloadTime})
-  , m_duration(computer.duration)
+                  SlotComponentData{.dbId      = computer.dbId,
+                                    .offensive = computer.offensive,
+                                    .powerCost = computer.powerCost,
+                                    .range     = computer.range,
+                                    // TODO: We should not convert to milliseconds here
+                                    .reloadTime = core::toMilliseconds(computer.reloadTime.count())})
   , m_allowedTargets(computer.allowedTargets)
   , m_damageModifier(computer.damageModifier)
-{}
+{
+  // TODO: We should not convert to milliseconds here.
+  if (computer.duration)
+  {
+    m_duration = core::toMilliseconds(computer.duration->count());
+  }
+}
 
 auto ComputerSlotComponent::duration() const -> std::optional<core::Duration>
 {

--- a/src/bsgo/components/WeaponSlotComponent.cc
+++ b/src/bsgo/components/WeaponSlotComponent.cc
@@ -5,11 +5,12 @@ namespace bsgo {
 
 WeaponSlotComponent::WeaponSlotComponent(const PlayerWeaponData &weapon)
   : SlotComponent(ComponentType::WEAPON_SLOT,
-                  SlotComponentData{.dbId       = weapon.dbId,
-                                    .offensive  = true,
-                                    .powerCost  = weapon.powerCost,
-                                    .range      = {weapon.range},
-                                    .reloadTime = weapon.reloadTime})
+                  SlotComponentData{.dbId      = weapon.dbId,
+                                    .offensive = true,
+                                    .powerCost = weapon.powerCost,
+                                    .range     = {weapon.range},
+                                    // TODO: We should not convert to milliseconds here
+                                    .reloadTime = core::toMilliseconds(weapon.reloadTime.count())})
   , m_minDamage(weapon.minDamage)
   , m_maxDamage(weapon.maxDamage)
 {

--- a/src/bsgo/data/PlayerComputerData.hh
+++ b/src/bsgo/data/PlayerComputerData.hh
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "EntityKind.hh"
-#include "TimeUtils.hh"
+#include "Tick.hh"
 #include "Uuid.hh"
 #include <optional>
 #include <unordered_set>
@@ -19,9 +19,9 @@ struct PlayerComputerData
   bool offensive{};
   float powerCost{};
   std::optional<float> range{};
-  core::Duration reloadTime{};
+  Tick reloadTime{};
 
-  std::optional<core::Duration> duration{};
+  std::optional<Tick> duration{};
   std::optional<std::unordered_set<EntityKind>> allowedTargets{};
   std::optional<float> damageModifier{};
 

--- a/src/bsgo/data/PlayerWeaponData.hh
+++ b/src/bsgo/data/PlayerWeaponData.hh
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "TimeUtils.hh"
+#include "Tick.hh"
 #include "Uuid.hh"
 #include <eigen3/Eigen/Eigen>
 #include <optional>
@@ -21,7 +21,7 @@ struct PlayerWeaponData
   float powerCost{};
   float range{};
 
-  core::Duration reloadTime{};
+  Tick reloadTime{};
 
   bool operator==(const PlayerWeaponData &rhs) const;
 };

--- a/src/bsgo/repositories/PlayerComputerRepository.cc
+++ b/src/bsgo/repositories/PlayerComputerRepository.cc
@@ -119,10 +119,10 @@ auto PlayerComputerRepository::fetchComputerBase(const Uuid computer) const -> P
   {
     out.range = {record[5].as<float>()};
   }
-  out.reloadTime = core::Milliseconds(record[6].as<int>());
+  out.reloadTime = Tick::fromInt(record[6].as<int>());
   if (!record[7].is_null())
   {
-    out.duration = {core::Milliseconds(record[7].as<int>())};
+    out.duration = Tick::fromInt(record[7].as<int>());
   }
   if (!record[8].is_null())
   {

--- a/src/bsgo/repositories/PlayerComputerRepository.hh
+++ b/src/bsgo/repositories/PlayerComputerRepository.hh
@@ -3,7 +3,7 @@
 
 #include "AbstractRepository.hh"
 #include "EntityKind.hh"
-#include "TimeUtils.hh"
+#include "Tick.hh"
 #include "Uuid.hh"
 #include <memory>
 #include <optional>
@@ -23,9 +23,9 @@ struct PlayerComputer
   bool offensive{};
   float powerCost{};
   std::optional<float> range{};
-  core::Duration reloadTime{};
+  Tick reloadTime{};
 
-  std::optional<core::Duration> duration{};
+  std::optional<Tick> duration{};
   std::optional<std::unordered_set<EntityKind>> allowedTargets{};
   std::optional<float> damageModifier{};
 };

--- a/src/bsgo/repositories/PlayerWeaponRepository.cc
+++ b/src/bsgo/repositories/PlayerWeaponRepository.cc
@@ -66,7 +66,7 @@ auto PlayerWeaponRepository::findOneById(const Uuid weapon) const -> PlayerWeapo
   out.maxDamage  = record[4].as<float>();
   out.powerCost  = record[5].as<float>();
   out.range      = record[6].as<float>();
-  out.reloadTime = core::Milliseconds(record[7].as<int>());
+  out.reloadTime = Tick::fromInt(record[7].as<int>());
   out.level      = record[8].as<int>();
 
   return out;

--- a/src/bsgo/repositories/PlayerWeaponRepository.hh
+++ b/src/bsgo/repositories/PlayerWeaponRepository.hh
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "AbstractRepository.hh"
-#include "TimeUtils.hh"
+#include "Tick.hh"
 #include "Uuid.hh"
 #include <memory>
 #include <optional>
@@ -26,7 +26,7 @@ struct PlayerWeapon
 
   float range{};
 
-  core::Duration reloadTime{};
+  Tick reloadTime{};
 };
 
 class PlayerWeaponRepository : public AbstractRepository

--- a/src/client/lib/ui/common/ShipItemUtils.cc
+++ b/src/client/lib/ui/common/ShipItemUtils.cc
@@ -66,11 +66,13 @@ auto generateWeaponMenu(const bsgo::WeaponData &weapon) -> UiMenuPtr
 
 auto generateWeaponMenu(const bsgo::PlayerWeaponData &weapon) -> UiMenuPtr
 {
+  // TODO: We should convert to seconds based on the tick duration
+  const auto reloadTime = core::toMilliseconds(weapon.reloadTime.count());
   return generateWeaponMenu(weapon.name,
                             weapon.minDamage,
                             weapon.maxDamage,
                             weapon.range,
-                            weapon.reloadTime);
+                            reloadTime);
 }
 
 auto generateComputerMenu(const std::string &name,
@@ -140,11 +142,19 @@ auto generateComputerMenu(const bsgo::ComputerData &computer) -> UiMenuPtr
 
 auto generateComputerMenu(const bsgo::PlayerComputerData &computer) -> UiMenuPtr
 {
+  // TODO: We should convert to seconds based on the tick duration
+  const auto reloadTime = core::toMilliseconds(computer.reloadTime.count());
+  std::optional<core::Duration> duration{};
+  if (computer.duration)
+  {
+    duration = core::toMilliseconds(computer.duration->count());
+  }
+
   return generateComputerMenu(computer.name,
                               computer.powerCost,
                               computer.range,
-                              computer.duration,
-                              computer.reloadTime);
+                              duration,
+                              reloadTime);
 }
 
 auto generateInteractiveSection(const std::string &buttonText,

--- a/tests/unit/bsgo/messages/Common.cc
+++ b/tests/unit/bsgo/messages/Common.cc
@@ -25,8 +25,16 @@ void assertPlayerComputerDataAreEqual(const PlayerComputerData &actual,
   EXPECT_EQ(actual.offensive, expected.offensive);
   EXPECT_EQ(actual.powerCost, expected.powerCost);
   EXPECT_EQ(actual.range, expected.range);
-  EXPECT_EQ(actual.reloadTime, expected.reloadTime);
-  EXPECT_EQ(actual.duration, expected.duration);
+
+  EXPECT_EQ(actual.reloadTime.count(), expected.reloadTime.count());
+  EXPECT_EQ(actual.reloadTime.frac(), expected.reloadTime.frac());
+  EXPECT_EQ(actual.duration.has_value(), expected.duration.has_value());
+  if (expected.duration.has_value())
+  {
+    EXPECT_EQ(actual.duration->count(), expected.duration->count());
+    EXPECT_EQ(actual.duration->frac(), expected.duration->frac());
+  }
+
   EXPECT_EQ(actual.allowedTargets, expected.allowedTargets);
   EXPECT_EQ(actual.damageModifier, expected.damageModifier);
 }
@@ -42,7 +50,9 @@ void assertPlayerWeaponDataAreEqual(const PlayerWeaponData &actual, const Player
   EXPECT_EQ(actual.maxDamage, expected.maxDamage);
   EXPECT_EQ(actual.powerCost, expected.powerCost);
   EXPECT_EQ(actual.range, expected.range);
-  EXPECT_EQ(actual.reloadTime, expected.reloadTime);
+
+  EXPECT_EQ(actual.reloadTime.count(), expected.reloadTime.count());
+  EXPECT_EQ(actual.reloadTime.frac(), expected.reloadTime.frac());
 }
 
 void assertOutpostDataAreEqual(const OutpostData &actual, const OutpostData &expected)

--- a/tests/unit/bsgo/messages/HangarMessageTest.cc
+++ b/tests/unit/bsgo/messages/HangarMessageTest.cc
@@ -40,9 +40,7 @@ TEST(Unit_Bsgo_Serialization_HangarMessage, WithShip)
                                 .weaponDbId = Uuid{65},
                                 .minDamage  = 45.87f,
                      },
-                              {.weaponDbId = Uuid{98},
-                               .name       = "weapon 1",
-                               .reloadTime = core::toMilliseconds(45)}},
+                              {.weaponDbId = Uuid{98}, .name = "weapon 1", .reloadTime = Tick::fromInt(45)}},
          .computers        = {{.computerDbId   = Uuid{12},
                                .offensive      = true,
                                .powerCost      = 56.47f,
@@ -52,7 +50,7 @@ TEST(Unit_Bsgo_Serialization_HangarMessage, WithShip)
                               {
                                 .dbId           = Uuid{27},
                                 .name           = "beefy computer",
-                                .reloadTime     = core::toMilliseconds(457),
+                                .reloadTime     = Tick(457, 0.174f),
                                 .damageModifier = 45.1f,
                        }}};
   const HangarMessage expected(data);
@@ -88,9 +86,7 @@ TEST(Unit_Bsgo_Serialization_HangarMessage, OverridesShipProperties)
                                 .weaponDbId = Uuid{65},
                                 .minDamage  = 45.87f,
                      },
-                              {.weaponDbId = Uuid{98},
-                               .name       = "weapon 1",
-                               .reloadTime = core::toMilliseconds(45)}},
+                              {.weaponDbId = Uuid{98}, .name = "weapon 1", .reloadTime = Tick(45, 0.712f)}},
          .computers        = {{.computerDbId   = Uuid{12},
                                .offensive      = true,
                                .powerCost      = 56.47f,
@@ -100,7 +96,7 @@ TEST(Unit_Bsgo_Serialization_HangarMessage, OverridesShipProperties)
                               {
                                 .dbId           = Uuid{27},
                                 .name           = "beefy computer",
-                                .reloadTime     = core::toMilliseconds(457),
+                                .reloadTime     = Tick::fromInt(457),
                                 .damageModifier = 45.1f,
                        }}};
   HangarMessage actual(data);

--- a/tests/unit/bsgo/messages/loading/PlayerComputerDataTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerComputerDataTest.cc
@@ -26,8 +26,8 @@ TEST(Unit_Bsgo_Serialization_PlayerComputerData, EqualWhenDbIdIsEqual)
   PlayerComputerData data2{
     .dbId       = Uuid{1234},
     .level      = 5,
-    .reloadTime = core::toMilliseconds(158),
-    .duration   = core::toMilliseconds(789),
+    .reloadTime = Tick::fromInt(158),
+    .duration   = Tick(789, 0.2357f),
   };
 
   EXPECT_TRUE(data1 == data2);
@@ -54,7 +54,7 @@ TEST(Unit_Bsgo_Serialization_PlayerComputerData, Basic)
                            .range          = 98765.1234f,
                            .damageModifier = 2.10987f};
 
-  PlayerComputerData output{.dbId = Uuid{14}, .level = 12, .reloadTime = core::toMilliseconds(1234)};
+  PlayerComputerData output{.dbId = Uuid{14}, .level = 12, .reloadTime = Tick::fromInt(1234)};
 
   EXPECT_TRUE(serializeAndDeserializeData(input, output));
 
@@ -72,7 +72,7 @@ TEST(Unit_Bsgo_Serialization_PlayerComputerData, AllowedTargets)
   PlayerComputerData output{.dbId       = Uuid{14},
                             .name       = "beefy computer",
                             .level      = 12,
-                            .reloadTime = core::toMilliseconds(1234)};
+                            .reloadTime = Tick(1234, 0.9541f)};
 
   EXPECT_TRUE(serializeAndDeserializeData(input, output));
 
@@ -90,7 +90,7 @@ TEST(Unit_Bsgo_Serialization_PlayerComputerData, NonEmptyAllowedTargetsInDestina
   PlayerComputerData output{.dbId       = Uuid{14},
                             .name       = "another computer",
                             .level      = 12,
-                            .reloadTime = core::toMilliseconds(1234)};
+                            .reloadTime = Tick(1234, 0.3247f)};
   output.allowedTargets = std::unordered_set<EntityKind>{EntityKind::OUTPOST};
 
   EXPECT_TRUE(serializeAndDeserializeData(input, output));

--- a/tests/unit/bsgo/messages/loading/PlayerComputerListMessageTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerComputerListMessageTest.cc
@@ -33,7 +33,7 @@ TEST(Unit_Bsgo_Serialization_PlayerComputerListMessage, Basic)
 
   const std::vector<PlayerComputerData>
     computersData{{.dbId = 23, .offensive = true, .damageModifier = -47.89f},
-                  {.dbId = 76, .level = 14, .duration = core::toMilliseconds(360)}};
+                  {.dbId = 76, .level = 14, .duration = Tick::fromInt(360)}};
   PlayerComputerListMessage actual(computersData);
   actual.setClientId(Uuid{2});
   serializeAndDeserializeMessage(expected, actual);
@@ -55,11 +55,11 @@ TEST(Unit_Bsgo_Serialization_PlayerComputerListMessage, WithClientId)
 
 TEST(Unit_Bsgo_Serialization_PlayerComputerListMessage, Clone)
 {
-  const std::vector<PlayerComputerData> computersData{
-    {.computerDbId   = 1908,
-     .level          = 12,
-     .allowedTargets = std::unordered_set<EntityKind>{EntityKind::ASTEROID}},
-    {.offensive = true, .powerCost = -3.9878f, .reloadTime = core::toMilliseconds(15001)}};
+  const std::vector<PlayerComputerData>
+    computersData{{.computerDbId   = 1908,
+                   .level          = 12,
+                   .allowedTargets = std::unordered_set<EntityKind>{EntityKind::ASTEROID}},
+                  {.offensive = true, .powerCost = -3.9878f, .reloadTime = Tick(15001, 0.2147f)}};
 
   const PlayerComputerListMessage expected(computersData);
 

--- a/tests/unit/bsgo/messages/loading/PlayerShipDataTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerShipDataTest.cc
@@ -140,7 +140,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipData, WithWeapons)
   });
   input.weapons.push_back({.dbId         = Uuid{6002},
                            .slotPosition = Eigen::Vector3f{-89.75f, -56.23f, 32.04f},
-                           .reloadTime   = core::toMilliseconds(12)});
+                           .reloadTime   = Tick(12, 0.73004f)});
 
   PlayerShipData output{.dbId    = Uuid{14},
                         .faction = Faction::CYLON,
@@ -183,7 +183,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipData, ClearsWeapons)
                             .maxDamage  = 20.0f,
                             .powerCost  = 5.0f,
                             .range      = 100.0f,
-                            .reloadTime = core::toMilliseconds(1234)});
+                            .reloadTime = Tick::fromInt(1234)});
 
   EXPECT_TRUE(serializeAndDeserializeMessage(input, output));
 

--- a/tests/unit/bsgo/messages/loading/PlayerShipListMessageTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerShipListMessageTest.cc
@@ -169,14 +169,9 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, CloneWithPlayer)
 
 TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, WithWeapon)
 {
-  std::vector<PlayerWeaponData> weapons{{.dbId       = Uuid{1},
-                                         .weaponDbId = Uuid{14},
-                                         .level      = 10,
-                                         .range      = 0.145f},
-                                        {.dbId       = Uuid{2},
-                                         .minDamage  = 14.2f,
-                                         .maxDamage  = 100.0f,
-                                         .reloadTime = core::toMilliseconds(23)}};
+  std::vector<PlayerWeaponData> weapons{
+    {.dbId = Uuid{1}, .weaponDbId = Uuid{14}, .level = 10, .range = 0.145f},
+    {.dbId = Uuid{2}, .minDamage = 14.2f, .maxDamage = 100.0f, .reloadTime = Tick::fromInt(23)}};
   std::vector<PlayerShipData> shipsData{{.dbId             = Uuid{65},
                                          .position         = Eigen::Vector3f(1.0f, 2.8f, 3.9f),
                                          .radius           = 26.9f,
@@ -189,7 +184,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, WithWeapon)
   expected.setPlayerDbId(Uuid{123});
   expected.setClientId(Uuid{78});
 
-  weapons = {{.dbId = Uuid{45}, .minDamage = 38.57f, .reloadTime = core::toMilliseconds(17)}};
+  weapons = {{.dbId = Uuid{45}, .minDamage = 38.57f, .reloadTime = Tick(17, 0.5422f)}};
   shipsData
     = {{.dbId        = Uuid{17},
         .powerPoints = 100.0f,
@@ -223,7 +218,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, WithComputer)
   expected.setPlayerDbId(Uuid{123});
   expected.setClientId(Uuid{78});
 
-  computers = {{.dbId = Uuid{45}, .level = 9, .reloadTime = core::toMilliseconds(17)}};
+  computers = {{.dbId = Uuid{45}, .level = 9, .reloadTime = Tick(17, 0.8201f)}};
   shipsData = {{.dbId = Uuid{17}, .powerPoints = 100.0f, .targetDbId = Uuid{923}},
                {.dbId = Uuid{18}, .radius = 26.1, .playerDbId = Uuid{456}}};
   PlayerShipListMessage actual(std::vector<PlayerShipData>{});
@@ -251,7 +246,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, MultipleComplexShips)
          .slotPosition = Eigen::Vector3f{45.12f, -56.89f, 78.45f},
          .minDamage    = 14.2f,
          .maxDamage    = 100.0f,
-         .reloadTime   = core::toMilliseconds(23)}},
+         .reloadTime   = Tick::fromInt(23)}},
      .computers
      = {{.dbId = Uuid{1}, .computerDbId = Uuid{14}, .level = 10, .offensive = true, .range = 0.145f},
         {.dbId           = Uuid{2},
@@ -309,7 +304,7 @@ TEST(Unit_Bsgo_Serialization_PlayerShipListMessage, MultipleComplexShips)
         .jumpTimeInThreat = Tick(5678.098f),
         .jumpSystem       = Uuid{7932},
         .weapons          = {
-                   {.weaponDbId = Uuid{852}, .name = "my weapon", .reloadTime = core::toMilliseconds(963)}}}};
+                   {.weaponDbId = Uuid{852}, .name = "my weapon", .reloadTime = Tick(963, 0.147f)}}}};
   PlayerShipListMessage actual(shipsData);
   actual.setSystemDbId(Uuid{3331});
   actual.setPlayerDbId(Uuid{745});

--- a/tests/unit/bsgo/messages/loading/PlayerWeaponDataTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerWeaponDataTest.cc
@@ -26,7 +26,7 @@ TEST(Unit_Bsgo_Serialization_PlayerWeaponData, EqualWhenDbIdIsEqual)
   PlayerWeaponData data2{.dbId       = Uuid{1234},
                          .level      = 5,
                          .maxDamage  = 17.5f,
-                         .reloadTime = core::toMilliseconds(158)};
+                         .reloadTime = Tick::fromInt(158)};
 
   EXPECT_TRUE(data1 == data2);
 }
@@ -53,9 +53,7 @@ TEST(Unit_Bsgo_Serialization_PlayerWeaponData, Basic)
                          .minDamage    = 5.4321f,
                          .range        = 98765.1234f};
 
-  PlayerWeaponData output{.dbId       = Uuid{14},
-                          .maxDamage  = 12.987f,
-                          .reloadTime = core::toMilliseconds(1234)};
+  PlayerWeaponData output{.dbId = Uuid{14}, .maxDamage = 12.987f, .reloadTime = Tick(1234, 0.456f)};
 
   EXPECT_TRUE(serializeAndDeserializeData(input, output));
 
@@ -69,7 +67,7 @@ TEST(Unit_Bsgo_Serialization_PlayerWeaponData, ErasesDestinationSlotPosition)
   PlayerWeaponData output{.dbId         = Uuid{14},
                           .slotPosition = Eigen::Vector3f{1.2f, 4.3f, -5.7f},
                           .maxDamage    = 12.987f,
-                          .reloadTime   = core::toMilliseconds(1234)};
+                          .reloadTime   = Tick(1234, 0.657102f)};
 
   EXPECT_TRUE(serializeAndDeserializeData(input, output));
 
@@ -89,7 +87,7 @@ TEST(Unit_Bsgo_Serialization_PlayerWeaponData, OverridesDestinationSlotPosition)
                           .slotPosition = Eigen::Vector3f{1.2f, 4.3f, -5.7f},
                           .name         = "another weapon",
                           .maxDamage    = 12.987f,
-                          .reloadTime   = core::toMilliseconds(1234)};
+                          .reloadTime   = Tick::fromInt(1234)};
 
   EXPECT_TRUE(serializeAndDeserializeData(input, output));
 

--- a/tests/unit/bsgo/messages/loading/PlayerWeaponListMessageTest.cc
+++ b/tests/unit/bsgo/messages/loading/PlayerWeaponListMessageTest.cc
@@ -32,7 +32,7 @@ TEST(Unit_Bsgo_Serialization_PlayerWeaponListMessage, Basic)
   const PlayerWeaponListMessage expected(std::vector<PlayerWeaponData>{});
 
   const std::vector<PlayerWeaponData> weaponsData{
-    {.dbId = 23, .range = 1.456f, .reloadTime = core::toMilliseconds(1546)},
+    {.dbId = 23, .range = 1.456f, .reloadTime = Tick::fromInt(1546)},
     {.dbId = 76, .slotPosition = Eigen::Vector3f(-7.8f, 45.12f, -0.458f), .minDamage = 14}};
   PlayerWeaponListMessage actual(weaponsData);
   actual.setClientId(Uuid{2});
@@ -51,7 +51,7 @@ TEST(Unit_Bsgo_Serialization_PlayerWeaponListMessage, WithClientId)
   expected.setClientId(Uuid{78});
 
   weaponsData = {{.weaponDbId = 2, .powerCost = 1.457f},
-                 {.maxDamage = 1.78f, .range = 5.64f, .reloadTime = core::toMilliseconds(7891)}};
+                 {.maxDamage = 1.78f, .range = 5.64f, .reloadTime = Tick(7891, 0.5413f)}};
   PlayerWeaponListMessage actual(weaponsData);
 
   serializeAndDeserializeMessage(expected, actual);
@@ -63,7 +63,7 @@ TEST(Unit_Bsgo_Serialization_PlayerWeaponListMessage, Clone)
 {
   const std::vector<PlayerWeaponData>
     weaponsData{{.weaponDbId = 1908, .level = 12, .minDamage = 7.451f},
-                {.level = 3, .powerCost = -3.9878f, .reloadTime = core::toMilliseconds(15001)}};
+                {.level = 3, .powerCost = -3.9878f, .reloadTime = Tick(15001, 0.03874f)}};
 
   const PlayerWeaponListMessage expected(weaponsData);
 


### PR DESCRIPTION
# Work

In #39 a library to manage time in a way that is not dependent of the real time simulation speed. This library allows to decouple the effects that rely on time (e.g. reload time, jump time, etc.) from real time.

In #41 and #42, the logic was used to replace the values used in ships for the jump time to use tick instead and in the shop's items (e.g. computers and weapons). This PR achieves a similar result by replacing the values in milliseconds and having them expressed in ticks for:
* player computers reload time and duration
* player weapons reload time

This is very similar to what happens for the shop's weapons and computers.

# Tests

It was verified locally that the game works correctly.

# Future work

As outlined in #41 we need to change the core logic in the `Coordinator` to use ticks. Additionally, the values used for player ships' data (weapons + computers) also need to be changed.
