### PR TITLE
feat: Used Tick in Coordinator

### DIFF
--- a/src/bsgo/controller/Coordinator.cc
+++ b/src/bsgo/controller/Coordinator.cc
@@ -392,9 +392,9 @@ auto Coordinator::getEntitiesWithinSatistying(const IBoundingBox &bbox,
   return out;
 }
 
-void Coordinator::update(float elapsedSeconds)
+void Coordinator::update(const TickData &data)
 {
-  m_systems->update(*this, elapsedSeconds);
+  m_systems->update(*this, data);
   cleanUpDeadEntities();
 }
 

--- a/src/bsgo/controller/Coordinator.hh
+++ b/src/bsgo/controller/Coordinator.hh
@@ -10,6 +10,7 @@
 #include "PlayerWeaponData.hh"
 #include "Systems.hh"
 #include "Tick.hh"
+#include "TickData.hh"
 #include "TimeUtils.hh"
 #include "Uuid.hh"
 #include <eigen3/Eigen/Eigen>
@@ -70,7 +71,7 @@ class Coordinator : public core::CoreObject
   auto getEntitiesWithinSatistying(const IBoundingBox &bbox, const EntityPredicate &predicate) const
     -> std::vector<Entity>;
 
-  void update(float elapsedSeconds);
+  void update(const TickData &data);
 
   private:
   Uuid m_nextEntity{Uuid(0)};

--- a/src/bsgo/controller/Systems.cc
+++ b/src/bsgo/controller/Systems.cc
@@ -25,11 +25,11 @@ Systems::Systems(SystemsConfig &&config)
   initialize(std::move(config));
 }
 
-void Systems::update(Coordinator &coordinator, const float elapsedSeconds) const
+void Systems::update(Coordinator &coordinator, const TickData &data) const
 {
   for (const auto &system : m_systems)
   {
-    system->update(coordinator, elapsedSeconds);
+    system->update(coordinator, data);
   }
 }
 

--- a/src/bsgo/controller/Systems.hh
+++ b/src/bsgo/controller/Systems.hh
@@ -24,7 +24,7 @@ class Systems : public core::CoreObject
   Systems(SystemsConfig &&config);
   ~Systems() override = default;
 
-  void update(Coordinator &coordinator, const float elapsedSeconds) const;
+  void update(Coordinator &coordinator, const TickData &data) const;
 
   private:
   std::vector<ISystemPtr> m_systems{};

--- a/src/bsgo/systems/AbstractSystem.cc
+++ b/src/bsgo/systems/AbstractSystem.cc
@@ -59,8 +59,11 @@ void AbstractSystem::update(Coordinator &coordinator, const TickData &data) cons
     }
 
     // TODO: We should not convert to a real time here.
-    constexpr auto MILLISECONDS_IN_A_SECOND = 1000.0f;
-    const auto elapsedSeconds               = data.elapsed.elapsed() / MILLISECONDS_IN_A_SECOND;
+    // The conversion is based on the fact that a tick is supposed to last
+    // 100 ms. Note that 0.1 can't be accurately represented in binary so
+    // this is losing precision.
+    constexpr auto SECONDS_IN_A_TICK = 0.1f;
+    const auto elapsedSeconds        = data.elapsed.elapsed() * SECONDS_IN_A_TICK;
 
     updateEntity(ent, coordinator, elapsedSeconds);
   }

--- a/src/bsgo/systems/AbstractSystem.cc
+++ b/src/bsgo/systems/AbstractSystem.cc
@@ -42,7 +42,7 @@ void AbstractSystem::installOutputMessageQueue(IMessageQueue *messageQueue)
   m_outputMessageQueue = messageQueue;
 }
 
-void AbstractSystem::update(Coordinator &coordinator, const float elapsedSeconds) const
+void AbstractSystem::update(Coordinator &coordinator, const TickData &data) const
 {
   /// https://gamedev.stackexchange.com/questions/71711/ecs-how-to-access-multiple-components-not-the-same-one-in-a-system
   auto entities = coordinator.getEntitiesSatistying(m_entitiesFilter);
@@ -57,6 +57,10 @@ void AbstractSystem::update(Coordinator &coordinator, const float elapsedSeconds
         continue;
       }
     }
+
+    // TODO: We should not convert to a real time here.
+    constexpr auto MILLISECONDS_IN_A_SECOND = 1000.0f;
+    const auto elapsedSeconds               = data.elapsed.elapsed() / MILLISECONDS_IN_A_SECOND;
 
     updateEntity(ent, coordinator, elapsedSeconds);
   }

--- a/src/bsgo/systems/AbstractSystem.hh
+++ b/src/bsgo/systems/AbstractSystem.hh
@@ -21,7 +21,7 @@ class AbstractSystem : public ISystem
   void installInternalMessageQueue(IMessageQueue *messageQueue) override;
   void installOutputMessageQueue(IMessageQueue *messageQueue) override;
 
-  void update(Coordinator &coordinator, const float elapsedSeconds) const override;
+  void update(Coordinator &coordinator, const TickData &data) const override;
 
   virtual void updateEntity(Entity &entity,
                             Coordinator &coordinator,

--- a/src/bsgo/systems/ISystem.hh
+++ b/src/bsgo/systems/ISystem.hh
@@ -5,6 +5,7 @@
 #include "CoreObject.hh"
 #include "IMessageQueue.hh"
 #include "SystemType.hh"
+#include "TickData.hh"
 #include <memory>
 
 namespace bsgo {
@@ -21,7 +22,7 @@ class ISystem : public core::CoreObject
   virtual void installInternalMessageQueue(IMessageQueue *messageQueue) = 0;
   virtual void installOutputMessageQueue(IMessageQueue *messageQueue)   = 0;
 
-  virtual void update(Coordinator &coordinator, const float elapsedSeconds) const = 0;
+  virtual void update(Coordinator &coordinator, const TickData &data) const = 0;
 };
 
 using ISystemPtr = std::unique_ptr<ISystem>;

--- a/src/client/lib/CMakeLists.txt
+++ b/src/client/lib/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries (client_lib
 	core_lib
 	pge_lib
 	bsgo_lib
+	time_lib
 	)
 
 target_include_directories (client_lib PUBLIC

--- a/src/client/lib/game/Game.hh
+++ b/src/client/lib/game/Game.hh
@@ -15,6 +15,7 @@
 #include "Renderer.hh"
 #include "RenderingPass.hh"
 #include "Screen.hh"
+#include "TimeManager.hh"
 #include "Views.hh"
 #include <memory>
 #include <unordered_map>
@@ -113,6 +114,7 @@ class Game : public core::CoreObject
   GameSessionShPtr m_gameSession{std::make_shared<GameSession>()};
 
   bsgo::DatabaseEntityMapper m_entityMapper{};
+  chrono::TimeManagerPtr m_timeManager{};
   bsgo::CoordinatorShPtr m_coordinator{};
   bsgo::IMessageQueuePtr m_inputMessageQueue{};
   bsgo::IMessageQueuePtr m_internalMessageQueue{};

--- a/src/server/lib/game/SystemProcessor.cc
+++ b/src/server/lib/game/SystemProcessor.cc
@@ -97,11 +97,11 @@ void SystemProcessor::asyncSystemProcessing()
       .elapsed = core::diffInMs(lastFrameTimestamp, thisFrameTimestamp),
     };
 
-    const auto tick = m_timeManager->tick(elapsed);
+    const auto data = m_timeManager->tick(elapsed);
+
+    m_coordinator->update(data);
 
     const auto elapsedSecond = elapsed.convert(chrono::Unit::SECONDS).elapsed;
-    m_coordinator->update(elapsedSecond);
-
     m_processes.update(*m_coordinator, elapsedSecond);
     m_inputMessagesQueue->processMessages();
 

--- a/src/time/TimeManager.cc
+++ b/src/time/TimeManager.cc
@@ -17,7 +17,7 @@ auto TimeManager::tick(const Duration elapsed) -> bsgo::TickData
   const auto tick = m_step.count(elapsed);
   m_currentTick += tick;
 
-  debug(elapsed.str() + " elapsed, tick: " + m_currentTick.str() + " (delta: " + tick.str() + ")");
+  verbose(elapsed.str() + " elapsed, tick: " + m_currentTick.str() + " (delta: " + tick.str() + ")");
 
   return bsgo::TickData{
     .tick    = m_currentTick,


### PR DESCRIPTION
# Work

In #39, a library to handle time management was added to the project. This library was used in #41, #42 and #43 to interpret information from the database: the goal was to decouple the actual duration of in-game events from real time.

However the core game logic (i.e. what happens in the `Coordinator`) still uses real time: we just convert the ticks we receive from the database to milliseconds.

A first step to change this is to update the interface of the `Coordinator` and the `Systems` classes to not take a floating point value representing the elapsed seconds but rather the data of the current tick. This PR brings the necessary changes to support this change.

In order to make this work, the `Game` class also needed to be updated: as it was so far not using a `TimeManager` at all, this PR changes the logic to instantiate it in a similar way to what is done in the `SystemProcessor` class and use it to feed the `Coordinator`.

# Tests

Verified locally that the game works as expected. In particular:
* reload of computers/weapons
* jump time
* velocity/acceleration

# Future work

We need to update both the `IComponent` and the `ISystem` interfaces to also receive a tick and not the elapsed seconds. This will effectively decouple the time management logic in the game from real world time.

Additionally the client applications are currently assuming the start tick and the time step to be used: this should change and be provided by the server upon connection.
