### PR TITLE
wip: Changed IComponent and ISystem interfaces

### DIFF
--- a/src/bsgo/components/AIComponent.cc
+++ b/src/bsgo/components/AIComponent.cc
@@ -23,6 +23,6 @@ auto AIComponent::behavior() const -> const INode &
   return *m_behavior;
 }
 
-void AIComponent::update(const float /*elapsedSeconds*/) {}
+void AIComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/AIComponent.hh
+++ b/src/bsgo/components/AIComponent.hh
@@ -15,7 +15,7 @@ class AIComponent : public AbstractComponent
   auto behavior() -> INode &;
   auto behavior() const -> const INode &;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   INodePtr m_behavior;

--- a/src/bsgo/components/DamageComponent.cc
+++ b/src/bsgo/components/DamageComponent.cc
@@ -13,6 +13,6 @@ auto DamageComponent::damage() const noexcept -> float
   return m_damage;
 }
 
-void DamageComponent::update(const float /*elapsedSeconds*/) {}
+void DamageComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/DamageComponent.hh
+++ b/src/bsgo/components/DamageComponent.hh
@@ -13,7 +13,7 @@ class DamageComponent : public AbstractComponent
 
   auto damage() const noexcept -> float;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   float m_damage;

--- a/src/bsgo/components/DbComponent.cc
+++ b/src/bsgo/components/DbComponent.cc
@@ -13,6 +13,6 @@ auto DbComponent::dbId() const noexcept -> Uuid
   return m_dbId;
 }
 
-void DbComponent::update(const float /*elapsedSeconds*/) {}
+void DbComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/DbComponent.hh
+++ b/src/bsgo/components/DbComponent.hh
@@ -14,7 +14,7 @@ class DbComponent : public AbstractComponent
 
   auto dbId() const noexcept -> Uuid;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   Uuid m_dbId{};

--- a/src/bsgo/components/EffectComponent.cc
+++ b/src/bsgo/components/EffectComponent.cc
@@ -12,10 +12,7 @@ EffectComponent::EffectComponent(const ComponentType &type, const TickDuration &
 
 bool EffectComponent::isFinished() const
 {
-  // TODO: We should not convert to milliseconds here.
-  constexpr auto MILLI_IN_ONE_SECOND = 1000.0f;
-  const auto durationAsTime = core::toMilliseconds(MILLI_IN_ONE_SECOND * m_duration.toSeconds());
-  return durationAsTime < m_elapsedSinceStart;
+  return m_duration < m_elapsedSinceStart;
 }
 
 auto EffectComponent::damageModifier() const -> std::optional<float>
@@ -23,11 +20,9 @@ auto EffectComponent::damageModifier() const -> std::optional<float>
   return {};
 }
 
-void EffectComponent::update(const float elapsedSeconds)
+void EffectComponent::update(const TickData &data)
 {
-  constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
-  m_elapsedSinceStart += core::Milliseconds(
-    static_cast<int>(elapsedSeconds * MILLISECONDS_IN_A_SECONDS));
+  m_elapsedSinceStart += data.elapsed;
 }
 
 } // namespace bsgo

--- a/src/bsgo/components/EffectComponent.hh
+++ b/src/bsgo/components/EffectComponent.hh
@@ -2,12 +2,11 @@
 #pragma once
 
 #include "AbstractComponent.hh"
+#include "Tick.hh"
 #include "TickDuration.hh"
-#include "TimeUtils.hh"
 #include <optional>
 
 namespace bsgo {
-
 class EffectComponent : public AbstractComponent
 {
   public:
@@ -18,11 +17,11 @@ class EffectComponent : public AbstractComponent
 
   virtual auto damageModifier() const -> std::optional<float>;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   TickDuration m_duration;
-  core::Duration m_elapsedSinceStart{};
+  TickDuration m_elapsedSinceStart{};
 };
 
 using EffectComponentShPtr = std::shared_ptr<EffectComponent>;

--- a/src/bsgo/components/FactionComponent.cc
+++ b/src/bsgo/components/FactionComponent.cc
@@ -13,6 +13,6 @@ auto FactionComponent::faction() const noexcept -> Faction
   return m_faction;
 }
 
-void FactionComponent::update(const float /*elapsedSeconds*/) {}
+void FactionComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/FactionComponent.hh
+++ b/src/bsgo/components/FactionComponent.hh
@@ -14,7 +14,7 @@ class FactionComponent : public AbstractComponent
 
   auto faction() const noexcept -> Faction;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   Faction m_faction;

--- a/src/bsgo/components/IComponent.hh
+++ b/src/bsgo/components/IComponent.hh
@@ -3,6 +3,7 @@
 
 #include "ComponentType.hh"
 #include "CoreObject.hh"
+#include "TickData.hh"
 #include <memory>
 
 namespace bsgo {
@@ -15,7 +16,7 @@ class IComponent : public core::CoreObject
 
   virtual auto type() const -> ComponentType = 0;
 
-  virtual void update(const float elapsedSeconds) = 0;
+  virtual void update(const TickData &data) = 0;
 };
 
 using IComponentShPtr = std::shared_ptr<IComponent>;

--- a/src/bsgo/components/KindComponent.cc
+++ b/src/bsgo/components/KindComponent.cc
@@ -13,6 +13,6 @@ auto KindComponent::kind() const noexcept -> EntityKind
   return m_kind;
 }
 
-void KindComponent::update(const float /*elapsedSeconds*/) {}
+void KindComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/KindComponent.hh
+++ b/src/bsgo/components/KindComponent.hh
@@ -14,7 +14,7 @@ class KindComponent : public AbstractComponent
 
   auto kind() const noexcept -> EntityKind;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   EntityKind m_kind;

--- a/src/bsgo/components/LootComponent.cc
+++ b/src/bsgo/components/LootComponent.cc
@@ -22,6 +22,6 @@ void LootComponent::clearRecipients()
   m_recipients.clear();
 }
 
-void LootComponent::update(const float /*elapsedSeconds*/) {}
+void LootComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/LootComponent.hh
+++ b/src/bsgo/components/LootComponent.hh
@@ -18,7 +18,7 @@ class LootComponent : public AbstractComponent
   auto recipients() const -> std::unordered_set<Uuid>;
   void clearRecipients();
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   std::unordered_set<Uuid> m_recipients{};

--- a/src/bsgo/components/NameComponent.cc
+++ b/src/bsgo/components/NameComponent.cc
@@ -13,6 +13,6 @@ auto NameComponent::name() const noexcept -> std::string
   return m_name;
 }
 
-void NameComponent::update(const float /*elapsedSeconds*/) {}
+void NameComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/NameComponent.hh
+++ b/src/bsgo/components/NameComponent.hh
@@ -13,7 +13,7 @@ class NameComponent : public AbstractComponent
 
   auto name() const noexcept -> std::string;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   std::string m_name{};

--- a/src/bsgo/components/OwnerComponent.cc
+++ b/src/bsgo/components/OwnerComponent.cc
@@ -19,6 +19,6 @@ auto OwnerComponent::category() const -> OwnerType
   return m_ownerType;
 }
 
-void OwnerComponent::update(const float /*elapsedSeconds*/) {}
+void OwnerComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/OwnerComponent.hh
+++ b/src/bsgo/components/OwnerComponent.hh
@@ -22,7 +22,7 @@ class OwnerComponent : public AbstractComponent
   auto owner() const -> Uuid;
   auto category() const -> OwnerType;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   Uuid m_owner;

--- a/src/bsgo/components/RegenerativeComponent.cc
+++ b/src/bsgo/components/RegenerativeComponent.cc
@@ -8,19 +8,20 @@ RegenerativeComponent::RegenerativeComponent(const ComponentType &type,
                                              const float min,
                                              const float value,
                                              const float max,
-                                             const float regenPerSecond)
+                                             const float regenPerTick)
   : AbstractComponent(type)
   , m_min(min)
   , m_value(value)
   , m_max(max)
-  , m_regenPerSecond(regenPerSecond)
+  , m_regenPerTick(regenPerTick)
 {
   validate();
 }
 
-void RegenerativeComponent::update(const float elapsedSeconds)
+void RegenerativeComponent::update(const TickData &data)
 {
-  const auto updated = m_value + m_regenPerSecond * elapsedSeconds;
+  // TODO: Verify if this works, we use ticks as regen per ticks.
+  const auto updated = m_value + m_regenPerTick * data.elapsed;
   m_value            = std::clamp(updated, m_min, m_max);
 }
 
@@ -66,9 +67,9 @@ void RegenerativeComponent::validate()
     throw std::invalid_argument("Expected value (" + std::to_string(m_value)
                                 + ") to be smaller than max (" + std::to_string(m_max) + ")");
   }
-  if (m_regenPerSecond < 0.0f)
+  if (m_regenPerTick < 0.0f)
   {
-    throw std::invalid_argument("Expected regeneration (" + std::to_string(m_regenPerSecond)
+    throw std::invalid_argument("Expected regeneration (" + std::to_string(m_regenPerTick)
                                 + ") to be greater than 0");
   }
 }

--- a/src/bsgo/components/RegenerativeComponent.hh
+++ b/src/bsgo/components/RegenerativeComponent.hh
@@ -12,10 +12,10 @@ class RegenerativeComponent : public AbstractComponent
                         const float min,
                         const float value,
                         const float max,
-                        const float regenPerSecond);
+                        const float regenPerTick);
   ~RegenerativeComponent() override = default;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   auto min() const -> float;
   auto value() const -> float;
@@ -27,11 +27,11 @@ class RegenerativeComponent : public AbstractComponent
   void updateValue(const float delta);
 
   private:
-  float m_min;
-  float m_value;
-  float m_max;
+  float m_min{0.0f};
+  float m_value{0.0f};
+  float m_max{0.0f};
 
-  float m_regenPerSecond;
+  float m_regenPerTick{0.0f};
 
   void validate();
 };

--- a/src/bsgo/components/RemovalComponent.cc
+++ b/src/bsgo/components/RemovalComponent.cc
@@ -17,6 +17,6 @@ bool RemovalComponent::toBeDeleted() const
   return m_markedForRemoval;
 }
 
-void RemovalComponent::update(const float /*elapsedSeconds*/) {}
+void RemovalComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/RemovalComponent.hh
+++ b/src/bsgo/components/RemovalComponent.hh
@@ -14,7 +14,7 @@ class RemovalComponent : public AbstractComponent
   void markForRemoval(const bool toRemove = true);
   bool toBeDeleted() const;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   bool m_markedForRemoval{false};

--- a/src/bsgo/components/ResourceComponent.cc
+++ b/src/bsgo/components/ResourceComponent.cc
@@ -19,7 +19,7 @@ auto ResourceComponent::amount() const -> int
   return m_amount;
 }
 
-void ResourceComponent::update(const float /*elapsedSeconds*/) {}
+void ResourceComponent::update(const TickData & /*data*/) {}
 
 void ResourceComponent::setAmount(const int amount)
 {

--- a/src/bsgo/components/ResourceComponent.hh
+++ b/src/bsgo/components/ResourceComponent.hh
@@ -15,7 +15,7 @@ class ResourceComponent : public AbstractComponent
   auto resource() const -> Uuid;
   auto amount() const -> int;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   void setAmount(const int amount);
 

--- a/src/bsgo/components/ScannedComponent.cc
+++ b/src/bsgo/components/ScannedComponent.cc
@@ -22,6 +22,6 @@ void ScannedComponent::reset()
   m_scanned = false;
 }
 
-void ScannedComponent::update(const float /*elapsedSeconds*/) {}
+void ScannedComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/ScannedComponent.hh
+++ b/src/bsgo/components/ScannedComponent.hh
@@ -15,7 +15,7 @@ class ScannedComponent : public AbstractComponent
   void scan();
   void reset();
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   bool m_scanned{false};

--- a/src/bsgo/components/ShipClassComponent.cc
+++ b/src/bsgo/components/ShipClassComponent.cc
@@ -13,6 +13,6 @@ auto ShipClassComponent::shipClass() const noexcept -> ShipClass
   return m_shipClass;
 }
 
-void ShipClassComponent::update(const float /*elapsedSeconds*/) {}
+void ShipClassComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/ShipClassComponent.hh
+++ b/src/bsgo/components/ShipClassComponent.hh
@@ -14,7 +14,7 @@ class ShipClassComponent : public AbstractComponent
 
   auto shipClass() const noexcept -> ShipClass;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   ShipClass m_shipClass;

--- a/src/bsgo/components/SlotComponent.cc
+++ b/src/bsgo/components/SlotComponent.cc
@@ -14,9 +14,9 @@ SlotComponent::SlotComponent(const ComponentType &type, const SlotComponentData 
   addModule("slot");
 }
 
-void SlotComponent::update(const float elapsedSeconds)
+void SlotComponent::update(const TickData &data)
 {
-  handleReload(elapsedSeconds);
+  handleReload(data);
 }
 
 auto SlotComponent::dbId() const -> Uuid
@@ -120,7 +120,7 @@ void SlotComponent::clearFireRequest()
   m_fireRequest = false;
 }
 
-void SlotComponent::handleReload(const float elapsedSeconds)
+void SlotComponent::handleReload(const TickData &data)
 {
   if (!m_elapsedSinceLastFired)
   {

--- a/src/bsgo/components/SlotComponent.hh
+++ b/src/bsgo/components/SlotComponent.hh
@@ -34,7 +34,7 @@ class SlotComponent : public AbstractComponent
   SlotComponent(const ComponentType &type, const SlotComponentData &data);
   ~SlotComponent() override = default;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   auto dbId() const -> Uuid;
   bool isOffensive() const;
@@ -65,7 +65,7 @@ class SlotComponent : public AbstractComponent
   FiringState m_firingState{FiringState::READY};
   std::optional<core::Duration> m_elapsedSinceLastFired{};
 
-  void handleReload(const float elapsedSeconds);
+  void handleReload(const TickData &data);
 };
 
 } // namespace bsgo

--- a/src/bsgo/components/StatusComponent.cc
+++ b/src/bsgo/components/StatusComponent.cc
@@ -104,7 +104,7 @@ void StatusComponent::setStatus(const Status &status)
   m_elapsedSinceLastChange = core::Duration{0};
 }
 
-void StatusComponent::update(const float elapsedSeconds)
+void StatusComponent::update(const TickData &data)
 {
   constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
   const auto elapsedMillis                 = core::Milliseconds(

--- a/src/bsgo/components/StatusComponent.hh
+++ b/src/bsgo/components/StatusComponent.hh
@@ -31,7 +31,7 @@ class StatusComponent : public AbstractComponent
 
   void setStatus(const Status &status);
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   Status m_status;

--- a/src/bsgo/components/SyncComponent.cc
+++ b/src/bsgo/components/SyncComponent.cc
@@ -4,19 +4,19 @@
 namespace bsgo {
 
 namespace {
-constexpr auto BASE_SYNC_INTERVAL_MS = 1000;
-constexpr auto MAX_SYNC_JITTER_MS    = 100;
+constexpr auto BASE_SYNC_INTERVAL_TICK = 10;
+constexpr auto MAX_SYNC_JITTER_TICK    = 1;
 
-auto generateJitteredSyncInterval() -> core::Duration
+auto generateJitteredSyncInterval() -> TickDuration
 {
-  const auto jitteredSync = BASE_SYNC_INTERVAL_MS + std::rand() % MAX_SYNC_JITTER_MS;
-  return core::Milliseconds{jitteredSync};
+  const auto jitteredSync = BASE_SYNC_INTERVAL_TICK + std::rand() % MAX_SYNC_JITTER_TICK;
+  return TickDuration::fromInt(jitteredSync);
 }
 } // namespace
 
 SyncComponent::SyncComponent(const ComponentType type)
   : AbstractComponent(type)
-  , m_remainingUntilNextSync(generateJitteredSyncInterval())
+  , m_durationUntilNextSync(generateJitteredSyncInterval())
 {}
 
 bool SyncComponent::needsSync() const
@@ -32,17 +32,14 @@ void SyncComponent::markForSync(const bool needsSync)
 void SyncComponent::markAsJustSynced()
 {
   markForSync(false);
-  m_remainingUntilNextSync = generateJitteredSyncInterval();
+  m_durationUntilNextSync = generateJitteredSyncInterval();
+  m_elapsedSinceLastSync  = TickDuration();
 }
 
-void SyncComponent::update(const float elapsedSeconds)
+void SyncComponent::update(const TickData &data)
 {
-  constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
-  const auto elapsedMillis                 = core::Milliseconds(
-    static_cast<int>(elapsedSeconds * MILLISECONDS_IN_A_SECONDS));
-
-  m_remainingUntilNextSync -= elapsedMillis;
-  if (m_remainingUntilNextSync.count() < 0)
+  m_elapsedSinceLastSync += data.elapsed;
+  if (m_durationUntilNextSync < m_elapsedSinceLastSync)
   {
     m_needsSync = true;
   }

--- a/src/bsgo/components/SyncComponent.hh
+++ b/src/bsgo/components/SyncComponent.hh
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "AbstractComponent.hh"
-#include "TimeUtils.hh"
+#include "TickDuration.hh"
 
 namespace bsgo {
 
@@ -17,11 +17,12 @@ class SyncComponent : public AbstractComponent
   void markForSync(const bool needsSync = true);
   void markAsJustSynced();
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   bool m_needsSync{false};
-  core::Duration m_remainingUntilNextSync{};
+  TickDuration m_durationUntilNextSync{};
+  TickDuration m_elapsedSinceLastSync{};
 };
 
 } // namespace bsgo

--- a/src/bsgo/components/TargetComponent.cc
+++ b/src/bsgo/components/TargetComponent.cc
@@ -27,6 +27,6 @@ void TargetComponent::setTarget(const Uuid target)
   m_target = target;
 }
 
-void TargetComponent::update(const float /*elapsedSeconds*/) {}
+void TargetComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/TargetComponent.hh
+++ b/src/bsgo/components/TargetComponent.hh
@@ -18,7 +18,7 @@ class TargetComponent : public AbstractComponent
   void clearTarget();
   void setTarget(const Uuid target);
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   std::optional<Uuid> m_target{};

--- a/src/bsgo/components/TransformComponent.cc
+++ b/src/bsgo/components/TransformComponent.cc
@@ -64,7 +64,7 @@ void TransformComponent::setHeading(const float heading)
   m_heading = heading;
 }
 
-void TransformComponent::update(const float /*elapsedSeconds*/) {}
+void TransformComponent::update(const TickData & /*data*/) {}
 
 namespace {
 const Eigen::Vector3f Z_AXIS = Eigen::Vector3f(0.0, 0.0, 1.0);

--- a/src/bsgo/components/TransformComponent.hh
+++ b/src/bsgo/components/TransformComponent.hh
@@ -21,7 +21,7 @@ class TransformComponent : public AbstractComponent
   void overridePosition(const Eigen::Vector3f &position);
   void setHeading(const float heading);
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   auto transformToGlobal(const Eigen::Vector3f &localPos) const -> Eigen::Vector3f;
 

--- a/src/bsgo/components/VelocityComponent.cc
+++ b/src/bsgo/components/VelocityComponent.cc
@@ -56,15 +56,15 @@ void VelocityComponent::immobilize()
   m_speed        = Eigen::Vector3f::Zero();
 }
 
-void VelocityComponent::update(const float elapsedSeconds)
+void VelocityComponent::update(const TickData &data)
 {
   switch (m_speedMode)
   {
     case SpeedMode::FIXED:
-      updateFixedSpeed(elapsedSeconds);
+      updateFixedSpeed(data);
       break;
     case SpeedMode::VARIABLE:
-      updateVariableSpeed(elapsedSeconds);
+      updateVariableSpeed(data);
       break;
     default:
       error("Failed to updated velocity",
@@ -73,17 +73,19 @@ void VelocityComponent::update(const float elapsedSeconds)
   }
 }
 
-void VelocityComponent::updateFixedSpeed(const float /*elapsedSeconds*/)
+void VelocityComponent::updateFixedSpeed(const TickData & /*data*/)
 {
-  // Intentionally empty.
+  // Intentionally empty: fixed speed means no changes to the speed.
 }
 
-void VelocityComponent::updateVariableSpeed(const float elapsedSeconds)
+void VelocityComponent::updateVariableSpeed(const TickData &data)
 {
-  /// https://gamedev.stackexchange.com/questions/69404/how-should-i-implement-basic-spaceship-physics
-  m_speed += m_acceleration * elapsedSeconds;
+  // TODO: Make this cleaner.
+  const auto elapsed = 1.0f * data.elapsed;
+  // https://gamedev.stackexchange.com/questions/69404/how-should-i-implement-basic-spaceship-physics
+  m_speed += m_acceleration * elapsed;
 
-  Eigen::Vector3f friction = -FRICTION_ACCELERATION * elapsedSeconds * m_speed.normalized();
+  Eigen::Vector3f friction = -FRICTION_ACCELERATION * elapsed * m_speed.normalized();
   m_speed += friction;
 
   const auto speedNorm = m_speed.norm();

--- a/src/bsgo/components/VelocityComponent.hh
+++ b/src/bsgo/components/VelocityComponent.hh
@@ -54,7 +54,7 @@ class VelocityComponent : public AbstractComponent
 
   void immobilize();
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   SpeedMode m_speedMode;
@@ -64,8 +64,8 @@ class VelocityComponent : public AbstractComponent
   Eigen::Vector3f m_acceleration{Eigen::Vector3f::Zero()};
   Eigen::Vector3f m_speed{Eigen::Vector3f::Zero()};
 
-  void updateFixedSpeed(const float elapsedSeconds);
-  void updateVariableSpeed(const float elapsedSeconds);
+  void updateFixedSpeed(const TickData &data);
+  void updateVariableSpeed(const TickData &data);
 };
 
 using VelocityComponentShPtr = std::shared_ptr<VelocityComponent>;

--- a/src/bsgo/systems/AISystem.cc
+++ b/src/bsgo/systems/AISystem.cc
@@ -13,15 +13,13 @@ AISystem::AISystem()
   : AbstractSystem(SystemType::AI, isEntityRelevant)
 {}
 
-void AISystem::updateEntity(Entity &entity,
-                            Coordinator &coordinator,
-                            const float elapsedSeconds) const
+void AISystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &aiComp = entity.aiComp();
-  aiComp.update(elapsedSeconds);
+  aiComp.update(data);
 
-  BehaviorData data{.ent = entity, .coordinator = coordinator};
-  aiComp.behavior().tick(data);
+  BehaviorData aiData{.ent = entity, .coordinator = coordinator};
+  aiComp.behavior().tick(aiData);
 }
 
 } // namespace bsgo

--- a/src/bsgo/systems/AISystem.hh
+++ b/src/bsgo/systems/AISystem.hh
@@ -11,9 +11,7 @@ class AISystem : public AbstractSystem
   AISystem();
   ~AISystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 };
 
 } // namespace bsgo

--- a/src/bsgo/systems/AbstractSystem.cc
+++ b/src/bsgo/systems/AbstractSystem.cc
@@ -58,10 +58,7 @@ void AbstractSystem::update(Coordinator &coordinator, const TickData &data) cons
       }
     }
 
-    // TODO: We should not convert to a real time here.
-    const auto elapsedSeconds = data.elapsed.toSeconds();
-
-    updateEntity(ent, coordinator, elapsedSeconds);
+    updateEntity(ent, coordinator, data);
   }
 }
 

--- a/src/bsgo/systems/AbstractSystem.hh
+++ b/src/bsgo/systems/AbstractSystem.hh
@@ -23,11 +23,11 @@ class AbstractSystem : public ISystem
 
   void update(Coordinator &coordinator, const TickData &data) const override;
 
+  protected:
   virtual void updateEntity(Entity &entity,
                             Coordinator &coordinator,
-                            const float elapsedSeconds) const = 0;
+                            const TickData &data) const = 0;
 
-  protected:
   void pushInternalMessage(IMessagePtr message) const;
   void pushMessage(IMessagePtr message) const;
 

--- a/src/bsgo/systems/BulletSystem.cc
+++ b/src/bsgo/systems/BulletSystem.cc
@@ -16,7 +16,7 @@ BulletSystem::BulletSystem()
 
 void BulletSystem::updateEntity(Entity &entity,
                                 Coordinator &coordinator,
-                                const float /*elapsedSeconds*/) const
+                                const TickData & /*data*/) const
 {
   if (isTargetNotExistent(entity))
   {

--- a/src/bsgo/systems/BulletSystem.hh
+++ b/src/bsgo/systems/BulletSystem.hh
@@ -11,9 +11,7 @@ class BulletSystem : public AbstractSystem
   BulletSystem();
   ~BulletSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   bool isTargetNotExistent(const Entity &entity) const;

--- a/src/bsgo/systems/ComputerSystem.cc
+++ b/src/bsgo/systems/ComputerSystem.cc
@@ -26,7 +26,7 @@ ComputerSystem::ComputerSystem()
 
 void ComputerSystem::updateEntity(Entity &entity,
                                   Coordinator &coordinator,
-                                  const float elapsedSeconds) const
+                                  const TickData &data) const
 {
   std::optional<Entity> targetEnt;
   auto target = entity.targetComp().target();
@@ -42,7 +42,7 @@ void ComputerSystem::updateEntity(Entity &entity,
 
   for (const auto &computer : entity.computers)
   {
-    updateComputer(entity, computer, targetEnt, elapsedSeconds);
+    updateComputer(entity, computer, targetEnt, data);
     if (computer->hasFireRequest())
     {
       if (processFireRequest(entity, computer, targetEnt, coordinator))
@@ -56,11 +56,11 @@ void ComputerSystem::updateEntity(Entity &entity,
 void ComputerSystem::updateComputer(const Entity &ent,
                                     const ComputerSlotComponentShPtr &computer,
                                     const std::optional<Entity> &target,
-                                    const float elapsedSeconds) const
+                                    const TickData &data) const
 {
   auto state{FiringState::READY};
 
-  computer->update(elapsedSeconds);
+  computer->update(data);
 
   if (computer->isOffensive() && (!target.has_value() || !isValidTarget(ent, *target, *computer)))
   {

--- a/src/bsgo/systems/ComputerSystem.hh
+++ b/src/bsgo/systems/ComputerSystem.hh
@@ -11,15 +11,13 @@ class ComputerSystem : public AbstractSystem
   ComputerSystem();
   ~ComputerSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void updateComputer(const Entity &ent,
                       const ComputerSlotComponentShPtr &computer,
                       const std::optional<Entity> &target,
-                      const float elapsedSeconds) const;
+                      const TickData &data) const;
 
   bool processFireRequest(Entity &ent,
                           const ComputerSlotComponentShPtr &computer,

--- a/src/bsgo/systems/EffectSystem.cc
+++ b/src/bsgo/systems/EffectSystem.cc
@@ -14,13 +14,11 @@ EffectSystem::EffectSystem()
   : AbstractSystem(SystemType::EFFECT, isEntityRelevant)
 {}
 
-void EffectSystem::updateEntity(Entity &entity,
-                                Coordinator &coordinator,
-                                const float elapsedSeconds) const
+void EffectSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   for (const auto &effect : entity.effects)
   {
-    effect->update(elapsedSeconds);
+    effect->update(data);
   }
 
   cleanUpFinishedEffects(entity, coordinator);

--- a/src/bsgo/systems/EffectSystem.hh
+++ b/src/bsgo/systems/EffectSystem.hh
@@ -11,9 +11,7 @@ class EffectSystem : public AbstractSystem
   EffectSystem();
   ~EffectSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void cleanUpFinishedEffects(const Entity &entity, Coordinator &coordinator) const;

--- a/src/bsgo/systems/HealthSystem.cc
+++ b/src/bsgo/systems/HealthSystem.cc
@@ -15,7 +15,7 @@ HealthSystem::HealthSystem()
 
 void HealthSystem::updateEntity(Entity &entity,
                                 Coordinator & /*coordinator*/,
-                                const float elapsedSeconds) const
+                                const TickData &data) const
 {
   if (tryMarkForDelettion(entity))
   {
@@ -26,7 +26,7 @@ void HealthSystem::updateEntity(Entity &entity,
 
   if (canRegenerateHealth(entity))
   {
-    entity.healthComp().update(elapsedSeconds);
+    entity.healthComp().update(data);
   }
 }
 

--- a/src/bsgo/systems/HealthSystem.hh
+++ b/src/bsgo/systems/HealthSystem.hh
@@ -11,9 +11,7 @@ class HealthSystem : public AbstractSystem
   HealthSystem();
   ~HealthSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   bool tryMarkForDelettion(Entity &entity) const;

--- a/src/bsgo/systems/LootSystem.cc
+++ b/src/bsgo/systems/LootSystem.cc
@@ -15,11 +15,9 @@ LootSystem::LootSystem()
   : AbstractSystem(SystemType::LOOT, isEntityRelevant)
 {}
 
-void LootSystem::updateEntity(Entity &entity,
-                              Coordinator &coordinator,
-                              const float elapsedSeconds) const
+void LootSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
-  entity.lootComp().update(elapsedSeconds);
+  entity.lootComp().update(data);
 
   const auto &health = entity.healthComp();
   if (health.isAlive())

--- a/src/bsgo/systems/LootSystem.hh
+++ b/src/bsgo/systems/LootSystem.hh
@@ -11,9 +11,7 @@ class LootSystem : public AbstractSystem
   LootSystem();
   ~LootSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void distributeLoot(const Entity &entity, Coordinator &coordinator) const;

--- a/src/bsgo/systems/MotionSystem.cc
+++ b/src/bsgo/systems/MotionSystem.cc
@@ -15,12 +15,19 @@ MotionSystem::MotionSystem()
 
 void MotionSystem::updateEntity(Entity &entity,
                                 Coordinator & /*coordinator*/,
-                                const float elapsedSeconds) const
+                                const TickData &data) const
 {
   auto &velocity  = entity.velocityComp();
   auto &transform = entity.transformComp();
 
-  velocity.update(elapsedSeconds);
+  velocity.update(data);
+
+  // TODO: We should not convert to a real time here.
+  // The conversion is based on the fact that a tick is supposed to last
+  // 100 ms. Note that 0.1 can't be accurately represented in binary so
+  // this is losing precision.
+  constexpr auto SECONDS_IN_A_TICK = 0.1f;
+  const auto elapsedSeconds        = data.elapsed.elapsed() * SECONDS_IN_A_TICK;
 
   const Eigen::Vector3f speed = velocity.speed();
   Eigen::Vector3f dv          = speed * elapsedSeconds;

--- a/src/bsgo/systems/MotionSystem.hh
+++ b/src/bsgo/systems/MotionSystem.hh
@@ -11,9 +11,7 @@ class MotionSystem : public AbstractSystem
   MotionSystem();
   ~MotionSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 };
 
 } // namespace bsgo

--- a/src/bsgo/systems/NetworkSystem.cc
+++ b/src/bsgo/systems/NetworkSystem.cc
@@ -16,10 +16,10 @@ NetworkSystem::NetworkSystem()
 
 void NetworkSystem::updateEntity(Entity &entity,
                                  Coordinator & /*coordinator*/,
-                                 const float elapsedSeconds) const
+                                 const TickData &data) const
 {
   auto &networkSyncComp = entity.networkSyncComp();
-  networkSyncComp.update(elapsedSeconds);
+  networkSyncComp.update(data);
 
   if (!networkSyncComp.needsSync())
   {

--- a/src/bsgo/systems/NetworkSystem.hh
+++ b/src/bsgo/systems/NetworkSystem.hh
@@ -12,9 +12,7 @@ class NetworkSystem : public AbstractSystem
   NetworkSystem();
   ~NetworkSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void syncEntity(Entity &entity) const;

--- a/src/bsgo/systems/PowerSystem.cc
+++ b/src/bsgo/systems/PowerSystem.cc
@@ -15,11 +15,11 @@ PowerSystem::PowerSystem()
 
 void PowerSystem::updateEntity(Entity &entity,
                                Coordinator & /*coordinator*/,
-                               const float elapsedSeconds) const
+                               const TickData &data) const
 {
   if (canRegeneratePower(entity))
   {
-    entity.powerComp().update(elapsedSeconds);
+    entity.powerComp().update(data);
   }
 }
 

--- a/src/bsgo/systems/PowerSystem.hh
+++ b/src/bsgo/systems/PowerSystem.hh
@@ -11,9 +11,7 @@ class PowerSystem : public AbstractSystem
   PowerSystem();
   ~PowerSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   bool canRegeneratePower(Entity &entity) const;

--- a/src/bsgo/systems/RemovalSystem.cc
+++ b/src/bsgo/systems/RemovalSystem.cc
@@ -17,9 +17,9 @@ RemovalSystem::RemovalSystem()
 
 void RemovalSystem::updateEntity(Entity &entity,
                                  Coordinator & /*coordinator*/,
-                                 const float elapsedSeconds) const
+                                 const TickData &data) const
 {
-  entity.removalComp().update(elapsedSeconds);
+  entity.removalComp().update(data);
 
   auto removalFromStatus{false};
   if (entity.exists<StatusComponent>())

--- a/src/bsgo/systems/RemovalSystem.hh
+++ b/src/bsgo/systems/RemovalSystem.hh
@@ -11,9 +11,7 @@ class RemovalSystem : public AbstractSystem
   RemovalSystem();
   ~RemovalSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void markEntityForRemoval(Entity &entity) const;

--- a/src/bsgo/systems/StatusSystem.cc
+++ b/src/bsgo/systems/StatusSystem.cc
@@ -18,12 +18,10 @@ StatusSystem::StatusSystem()
 constexpr auto TIME_TO_STAY_IN_APPEARED_MODE = core::Milliseconds{10'000};
 constexpr auto TIME_TO_STAY_IN_THREAT_MODE   = core::Milliseconds{3'000};
 
-void StatusSystem::updateEntity(Entity &entity,
-                                Coordinator &coordinator,
-                                const float elapsedSeconds) const
+void StatusSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &statusComp = entity.statusComp();
-  statusComp.update(elapsedSeconds);
+  statusComp.update(data);
 
   handleAppearingState(entity, statusComp);
   handleThreatState(entity, statusComp);
@@ -98,6 +96,8 @@ void StatusSystem::handleJumpState(Entity &entity,
   }
 
   const auto remaining = statusComp.tryGetRemainingJumpTime();
+
+  // TODO: Should probably be a > and not >=
   if (remaining >= core::Duration{0})
   {
     return;

--- a/src/bsgo/systems/StatusSystem.hh
+++ b/src/bsgo/systems/StatusSystem.hh
@@ -11,9 +11,7 @@ class StatusSystem : public AbstractSystem
   StatusSystem();
   ~StatusSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void handleAppearingState(Entity &entity, StatusComponent &statusComp) const;

--- a/src/bsgo/systems/TargetSystem.cc
+++ b/src/bsgo/systems/TargetSystem.cc
@@ -14,12 +14,10 @@ TargetSystem::TargetSystem()
   : AbstractSystem(SystemType::TARGET, isEntityRelevant)
 {}
 
-void TargetSystem::updateEntity(Entity &entity,
-                                Coordinator &coordinator,
-                                const float elapsedSeconds) const
+void TargetSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &targetComp = entity.targetComp();
-  targetComp.update(elapsedSeconds);
+  targetComp.update(data);
 
   if (!targetComp.target())
   {

--- a/src/bsgo/systems/TargetSystem.hh
+++ b/src/bsgo/systems/TargetSystem.hh
@@ -11,9 +11,7 @@ class TargetSystem : public AbstractSystem
   TargetSystem();
   ~TargetSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void clearTargetIfNotReachable(TargetComponent &targetComp, const Coordinator &coordinator) const;

--- a/src/bsgo/systems/WeaponSystem.cc
+++ b/src/bsgo/systems/WeaponSystem.cc
@@ -17,9 +17,7 @@ WeaponSystem::WeaponSystem()
   : AbstractSystem(SystemType::WEAPON, isEntityRelevant)
 {}
 
-void WeaponSystem::updateEntity(Entity &entity,
-                                Coordinator &coordinator,
-                                const float elapsedSeconds) const
+void WeaponSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   const auto target = entity.targetComp().target();
 
@@ -36,7 +34,7 @@ void WeaponSystem::updateEntity(Entity &entity,
 
   for (const auto &weapon : entity.weapons)
   {
-    updateWeapon(entity, weapon, targetEnt, elapsedSeconds);
+    updateWeapon(entity, weapon, targetEnt, data);
     weapon->clearFireRequest();
     if (weapon->canFire())
     {
@@ -63,11 +61,11 @@ bool WeaponSystem::canTargetBeFiredOn(const Entity &target) const
 void WeaponSystem::updateWeapon(const Entity &ent,
                                 const WeaponSlotComponentShPtr &weapon,
                                 const std::optional<Entity> &target,
-                                const float elapsedSeconds) const
+                                const TickData &data) const
 {
   auto state{FiringState::READY};
 
-  weapon->update(elapsedSeconds);
+  weapon->update(data);
 
   if (!weapon->active())
   {

--- a/src/bsgo/systems/WeaponSystem.hh
+++ b/src/bsgo/systems/WeaponSystem.hh
@@ -12,9 +12,7 @@ class WeaponSystem : public AbstractSystem
   WeaponSystem();
   ~WeaponSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   bool canTargetBeFiredOn(const Entity &target) const;
@@ -22,7 +20,7 @@ class WeaponSystem : public AbstractSystem
   void updateWeapon(const Entity &ent,
                     const WeaponSlotComponentShPtr &weapon,
                     const std::optional<Entity> &target,
-                    const float elapsedSeconds) const;
+                    const TickData &data) const;
 
   void fireWeaponForEntity(Entity &ent,
                            WeaponSlotComponent &weapon,

--- a/src/bsgo/time/TickDuration.cc
+++ b/src/bsgo/time/TickDuration.cc
@@ -27,6 +27,17 @@ bool TickDuration::operator==(const TickDuration &rhs) const
   return diff < TickDuration::TOLERANCE;
 }
 
+auto TickDuration::operator+=(const TickDuration &duration) -> TickDuration &
+{
+  m_elapsed += duration.m_elapsed;
+  return *this;
+}
+
+auto TickDuration::operator*(const float lhs) const -> float
+{
+  return m_elapsed * lhs;
+}
+
 bool TickDuration::operator<(const TickDuration &rhs) const
 {
   return m_elapsed < rhs.m_elapsed;
@@ -80,6 +91,11 @@ void TickDuration::validate()
     throw std::invalid_argument("Tick duration cannot be negative, got: "
                                 + std::to_string(m_elapsed));
   }
+}
+
+auto operator*(const float lhs, const TickDuration &rhs) -> float
+{
+  return rhs * lhs;
 }
 
 } // namespace bsgo

--- a/src/bsgo/time/TickDuration.hh
+++ b/src/bsgo/time/TickDuration.hh
@@ -29,6 +29,10 @@ class TickDuration
   /// @return - true in case both durations are equal within the tolerance
   bool operator==(const TickDuration &rhs) const;
 
+  auto operator+=(const TickDuration &duration) -> TickDuration &;
+
+  auto operator*(const float lhs) const -> float;
+
   bool operator<(const TickDuration &rhs) const;
   bool operator<=(const TickDuration &rhs) const;
   bool operator>(const TickDuration &rhs) const;
@@ -66,5 +70,7 @@ class TickDuration
 
   void validate();
 };
+
+auto operator*(const float lhs, const TickDuration &rhs) -> float;
 
 } // namespace bsgo


### PR DESCRIPTION
# Work

## Context

In #39 a time management library was added. Throughout multiple PRs (notably #44, #45 and #46) but also individual commits, the game logic was progressively adapted to correctly manipulate ticks and not durations.

However, the core update loop (i.e. the work done in the systems) is still converting back to seconds for most of the processing. This needs to change to fully decouple the logic from real time.

## What needs to be done?

Two interfaces need to change: `IComponent` and `ISystem`. Both are currently having an update 

# Tests

# Future work
