### PR TITLE
feat: Used TickData in systems

### DIFF
--- a/src/bsgo/systems/AISystem.cc
+++ b/src/bsgo/systems/AISystem.cc
@@ -13,15 +13,14 @@ AISystem::AISystem()
   : AbstractSystem(SystemType::AI, isEntityRelevant)
 {}
 
-void AISystem::updateEntity(Entity &entity,
-                            Coordinator &coordinator,
-                            const float elapsedSeconds) const
+void AISystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &aiComp = entity.aiComp();
-  aiComp.update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  aiComp.update(data.elapsed.toSeconds());
 
-  BehaviorData data{.ent = entity, .coordinator = coordinator};
-  aiComp.behavior().tick(data);
+  BehaviorData aiData{.ent = entity, .coordinator = coordinator};
+  aiComp.behavior().tick(aiData);
 }
 
 } // namespace bsgo

--- a/src/bsgo/systems/AISystem.hh
+++ b/src/bsgo/systems/AISystem.hh
@@ -11,9 +11,8 @@ class AISystem : public AbstractSystem
   AISystem();
   ~AISystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 };
 
 } // namespace bsgo

--- a/src/bsgo/systems/AbstractSystem.cc
+++ b/src/bsgo/systems/AbstractSystem.cc
@@ -58,10 +58,7 @@ void AbstractSystem::update(Coordinator &coordinator, const TickData &data) cons
       }
     }
 
-    // TODO: We should not convert to a real time here.
-    const auto elapsedSeconds = data.elapsed.toSeconds();
-
-    updateEntity(ent, coordinator, elapsedSeconds);
+    updateEntity(ent, coordinator, data);
   }
 }
 

--- a/src/bsgo/systems/AbstractSystem.hh
+++ b/src/bsgo/systems/AbstractSystem.hh
@@ -23,13 +23,13 @@ class AbstractSystem : public ISystem
 
   void update(Coordinator &coordinator, const TickData &data) const override;
 
-  virtual void updateEntity(Entity &entity,
-                            Coordinator &coordinator,
-                            const float elapsedSeconds) const = 0;
-
   protected:
   void pushInternalMessage(IMessagePtr message) const;
   void pushMessage(IMessagePtr message) const;
+
+  virtual void updateEntity(Entity &entity,
+                            Coordinator &coordinator,
+                            const TickData &data) const = 0;
 
   private:
   SystemType m_systemType{};

--- a/src/bsgo/systems/BulletSystem.cc
+++ b/src/bsgo/systems/BulletSystem.cc
@@ -16,7 +16,7 @@ BulletSystem::BulletSystem()
 
 void BulletSystem::updateEntity(Entity &entity,
                                 Coordinator &coordinator,
-                                const float /*elapsedSeconds*/) const
+                                const TickData & /*data*/) const
 {
   if (isTargetNotExistent(entity))
   {

--- a/src/bsgo/systems/BulletSystem.hh
+++ b/src/bsgo/systems/BulletSystem.hh
@@ -11,9 +11,9 @@ class BulletSystem : public AbstractSystem
   BulletSystem();
   ~BulletSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   bool isTargetNotExistent(const Entity &entity) const;

--- a/src/bsgo/systems/ComputerSystem.cc
+++ b/src/bsgo/systems/ComputerSystem.cc
@@ -26,7 +26,7 @@ ComputerSystem::ComputerSystem()
 
 void ComputerSystem::updateEntity(Entity &entity,
                                   Coordinator &coordinator,
-                                  const float elapsedSeconds) const
+                                  const TickData &data) const
 {
   std::optional<Entity> targetEnt;
   auto target = entity.targetComp().target();
@@ -42,7 +42,7 @@ void ComputerSystem::updateEntity(Entity &entity,
 
   for (const auto &computer : entity.computers)
   {
-    updateComputer(entity, computer, targetEnt, elapsedSeconds);
+    updateComputer(entity, computer, targetEnt, data);
     if (computer->hasFireRequest())
     {
       if (processFireRequest(entity, computer, targetEnt, coordinator))
@@ -56,11 +56,12 @@ void ComputerSystem::updateEntity(Entity &entity,
 void ComputerSystem::updateComputer(const Entity &ent,
                                     const ComputerSlotComponentShPtr &computer,
                                     const std::optional<Entity> &target,
-                                    const float elapsedSeconds) const
+                                    const TickData &data) const
 {
   auto state{FiringState::READY};
 
-  computer->update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  computer->update(data.elapsed.toSeconds());
 
   if (computer->isOffensive() && (!target.has_value() || !isValidTarget(ent, *target, *computer)))
   {

--- a/src/bsgo/systems/ComputerSystem.hh
+++ b/src/bsgo/systems/ComputerSystem.hh
@@ -11,15 +11,14 @@ class ComputerSystem : public AbstractSystem
   ComputerSystem();
   ~ComputerSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void updateComputer(const Entity &ent,
                       const ComputerSlotComponentShPtr &computer,
                       const std::optional<Entity> &target,
-                      const float elapsedSeconds) const;
+                      const TickData &data) const;
 
   bool processFireRequest(Entity &ent,
                           const ComputerSlotComponentShPtr &computer,

--- a/src/bsgo/systems/EffectSystem.cc
+++ b/src/bsgo/systems/EffectSystem.cc
@@ -14,13 +14,12 @@ EffectSystem::EffectSystem()
   : AbstractSystem(SystemType::EFFECT, isEntityRelevant)
 {}
 
-void EffectSystem::updateEntity(Entity &entity,
-                                Coordinator &coordinator,
-                                const float elapsedSeconds) const
+void EffectSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   for (const auto &effect : entity.effects)
   {
-    effect->update(elapsedSeconds);
+    // TODO: We should use the tick duration as is.
+    effect->update(data.elapsed.toSeconds());
   }
 
   cleanUpFinishedEffects(entity, coordinator);

--- a/src/bsgo/systems/EffectSystem.hh
+++ b/src/bsgo/systems/EffectSystem.hh
@@ -11,9 +11,8 @@ class EffectSystem : public AbstractSystem
   EffectSystem();
   ~EffectSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void cleanUpFinishedEffects(const Entity &entity, Coordinator &coordinator) const;

--- a/src/bsgo/systems/HealthSystem.cc
+++ b/src/bsgo/systems/HealthSystem.cc
@@ -15,7 +15,7 @@ HealthSystem::HealthSystem()
 
 void HealthSystem::updateEntity(Entity &entity,
                                 Coordinator & /*coordinator*/,
-                                const float elapsedSeconds) const
+                                const TickData &data) const
 {
   if (tryMarkForDelettion(entity))
   {
@@ -26,7 +26,8 @@ void HealthSystem::updateEntity(Entity &entity,
 
   if (canRegenerateHealth(entity))
   {
-    entity.healthComp().update(elapsedSeconds);
+    // TODO: We should use the tick duration as is.
+    entity.healthComp().update(data.elapsed.toSeconds());
   }
 }
 

--- a/src/bsgo/systems/HealthSystem.hh
+++ b/src/bsgo/systems/HealthSystem.hh
@@ -11,9 +11,8 @@ class HealthSystem : public AbstractSystem
   HealthSystem();
   ~HealthSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   bool tryMarkForDelettion(Entity &entity) const;

--- a/src/bsgo/systems/LootSystem.cc
+++ b/src/bsgo/systems/LootSystem.cc
@@ -15,11 +15,10 @@ LootSystem::LootSystem()
   : AbstractSystem(SystemType::LOOT, isEntityRelevant)
 {}
 
-void LootSystem::updateEntity(Entity &entity,
-                              Coordinator &coordinator,
-                              const float elapsedSeconds) const
+void LootSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
-  entity.lootComp().update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  entity.lootComp().update(data.elapsed.toSeconds());
 
   const auto &health = entity.healthComp();
   if (health.isAlive())

--- a/src/bsgo/systems/LootSystem.hh
+++ b/src/bsgo/systems/LootSystem.hh
@@ -11,9 +11,8 @@ class LootSystem : public AbstractSystem
   LootSystem();
   ~LootSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void distributeLoot(const Entity &entity, Coordinator &coordinator) const;

--- a/src/bsgo/systems/MotionSystem.cc
+++ b/src/bsgo/systems/MotionSystem.cc
@@ -15,15 +15,17 @@ MotionSystem::MotionSystem()
 
 void MotionSystem::updateEntity(Entity &entity,
                                 Coordinator & /*coordinator*/,
-                                const float elapsedSeconds) const
+                                const TickData &data) const
 {
   auto &velocity  = entity.velocityComp();
   auto &transform = entity.transformComp();
 
-  velocity.update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  velocity.update(data.elapsed.toSeconds());
 
   const Eigen::Vector3f speed = velocity.speed();
-  Eigen::Vector3f dv          = speed * elapsedSeconds;
+  // TODO: We should use the tick duration as is.
+  Eigen::Vector3f dv = speed * data.elapsed.toSeconds();
   transform.translate(dv);
   if (!speed.isZero())
   {

--- a/src/bsgo/systems/MotionSystem.hh
+++ b/src/bsgo/systems/MotionSystem.hh
@@ -11,9 +11,8 @@ class MotionSystem : public AbstractSystem
   MotionSystem();
   ~MotionSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 };
 
 } // namespace bsgo

--- a/src/bsgo/systems/NetworkSystem.cc
+++ b/src/bsgo/systems/NetworkSystem.cc
@@ -16,10 +16,11 @@ NetworkSystem::NetworkSystem()
 
 void NetworkSystem::updateEntity(Entity &entity,
                                  Coordinator & /*coordinator*/,
-                                 const float elapsedSeconds) const
+                                 const TickData &data) const
 {
   auto &networkSyncComp = entity.networkSyncComp();
-  networkSyncComp.update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  networkSyncComp.update(data.elapsed.toSeconds());
 
   if (!networkSyncComp.needsSync())
   {

--- a/src/bsgo/systems/NetworkSystem.hh
+++ b/src/bsgo/systems/NetworkSystem.hh
@@ -12,9 +12,8 @@ class NetworkSystem : public AbstractSystem
   NetworkSystem();
   ~NetworkSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void syncEntity(Entity &entity) const;

--- a/src/bsgo/systems/PowerSystem.cc
+++ b/src/bsgo/systems/PowerSystem.cc
@@ -15,11 +15,12 @@ PowerSystem::PowerSystem()
 
 void PowerSystem::updateEntity(Entity &entity,
                                Coordinator & /*coordinator*/,
-                               const float elapsedSeconds) const
+                               const TickData &data) const
 {
   if (canRegeneratePower(entity))
   {
-    entity.powerComp().update(elapsedSeconds);
+    // TODO: We should use the tick duration as is.
+    entity.powerComp().update(data.elapsed.toSeconds());
   }
 }
 

--- a/src/bsgo/systems/PowerSystem.hh
+++ b/src/bsgo/systems/PowerSystem.hh
@@ -11,9 +11,8 @@ class PowerSystem : public AbstractSystem
   PowerSystem();
   ~PowerSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   bool canRegeneratePower(Entity &entity) const;

--- a/src/bsgo/systems/RemovalSystem.cc
+++ b/src/bsgo/systems/RemovalSystem.cc
@@ -17,9 +17,10 @@ RemovalSystem::RemovalSystem()
 
 void RemovalSystem::updateEntity(Entity &entity,
                                  Coordinator & /*coordinator*/,
-                                 const float elapsedSeconds) const
+                                 const TickData &data) const
 {
-  entity.removalComp().update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  entity.removalComp().update(data.elapsed.toSeconds());
 
   auto removalFromStatus{false};
   if (entity.exists<StatusComponent>())

--- a/src/bsgo/systems/RemovalSystem.hh
+++ b/src/bsgo/systems/RemovalSystem.hh
@@ -11,9 +11,8 @@ class RemovalSystem : public AbstractSystem
   RemovalSystem();
   ~RemovalSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void markEntityForRemoval(Entity &entity) const;

--- a/src/bsgo/systems/StatusSystem.cc
+++ b/src/bsgo/systems/StatusSystem.cc
@@ -18,12 +18,11 @@ StatusSystem::StatusSystem()
 constexpr auto TIME_TO_STAY_IN_APPEARED_MODE = core::Milliseconds{10'000};
 constexpr auto TIME_TO_STAY_IN_THREAT_MODE   = core::Milliseconds{3'000};
 
-void StatusSystem::updateEntity(Entity &entity,
-                                Coordinator &coordinator,
-                                const float elapsedSeconds) const
+void StatusSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &statusComp = entity.statusComp();
-  statusComp.update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  statusComp.update(data.elapsed.toSeconds());
 
   handleAppearingState(entity, statusComp);
   handleThreatState(entity, statusComp);

--- a/src/bsgo/systems/StatusSystem.hh
+++ b/src/bsgo/systems/StatusSystem.hh
@@ -11,9 +11,8 @@ class StatusSystem : public AbstractSystem
   StatusSystem();
   ~StatusSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void handleAppearingState(Entity &entity, StatusComponent &statusComp) const;

--- a/src/bsgo/systems/TargetSystem.cc
+++ b/src/bsgo/systems/TargetSystem.cc
@@ -14,12 +14,11 @@ TargetSystem::TargetSystem()
   : AbstractSystem(SystemType::TARGET, isEntityRelevant)
 {}
 
-void TargetSystem::updateEntity(Entity &entity,
-                                Coordinator &coordinator,
-                                const float elapsedSeconds) const
+void TargetSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &targetComp = entity.targetComp();
-  targetComp.update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  targetComp.update(data.elapsed.toSeconds());
 
   if (!targetComp.target())
   {

--- a/src/bsgo/systems/TargetSystem.hh
+++ b/src/bsgo/systems/TargetSystem.hh
@@ -11,9 +11,8 @@ class TargetSystem : public AbstractSystem
   TargetSystem();
   ~TargetSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void clearTargetIfNotReachable(TargetComponent &targetComp, const Coordinator &coordinator) const;

--- a/src/bsgo/systems/WeaponSystem.cc
+++ b/src/bsgo/systems/WeaponSystem.cc
@@ -17,9 +17,7 @@ WeaponSystem::WeaponSystem()
   : AbstractSystem(SystemType::WEAPON, isEntityRelevant)
 {}
 
-void WeaponSystem::updateEntity(Entity &entity,
-                                Coordinator &coordinator,
-                                const float elapsedSeconds) const
+void WeaponSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   const auto target = entity.targetComp().target();
 
@@ -36,7 +34,7 @@ void WeaponSystem::updateEntity(Entity &entity,
 
   for (const auto &weapon : entity.weapons)
   {
-    updateWeapon(entity, weapon, targetEnt, elapsedSeconds);
+    updateWeapon(entity, weapon, targetEnt, data);
     weapon->clearFireRequest();
     if (weapon->canFire())
     {
@@ -63,11 +61,12 @@ bool WeaponSystem::canTargetBeFiredOn(const Entity &target) const
 void WeaponSystem::updateWeapon(const Entity &ent,
                                 const WeaponSlotComponentShPtr &weapon,
                                 const std::optional<Entity> &target,
-                                const float elapsedSeconds) const
+                                const TickData &data) const
 {
   auto state{FiringState::READY};
 
-  weapon->update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  weapon->update(data.elapsed.toSeconds());
 
   if (!weapon->active())
   {

--- a/src/bsgo/systems/WeaponSystem.hh
+++ b/src/bsgo/systems/WeaponSystem.hh
@@ -12,9 +12,8 @@ class WeaponSystem : public AbstractSystem
   WeaponSystem();
   ~WeaponSystem() override = default;
 
-  void updateEntity(Entity &entity,
-                    Coordinator &coordinator,
-                    const float elapsedSeconds) const override;
+  protected:
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const override;
 
   private:
   bool canTargetBeFiredOn(const Entity &target) const;
@@ -22,7 +21,7 @@ class WeaponSystem : public AbstractSystem
   void updateWeapon(const Entity &ent,
                     const WeaponSlotComponentShPtr &weapon,
                     const std::optional<Entity> &target,
-                    const float elapsedSeconds) const;
+                    const TickData &data) const;
 
   void fireWeaponForEntity(Entity &ent,
                            WeaponSlotComponent &weapon,


### PR DESCRIPTION
# Work

In #44 the game logic was changed so that the `Coordinator` and the `ISystem` interface take `TickData` as input of the update method rather than a raw floating point value representing the elapsed seconds. This step is important in replacing the game logic to not rely on real time.

This PR continues the work by also changing individual systems (e.g. bullet system, health system, etc.) to also take a `TickData` argument in the `updateEntity` method.

The goal of this change is to reduce the surface of change to fully replace the real time usage in the game logic. This will allow to gradually replace the systems as needed.

Currently this change is far from complete: we merely changed the argument and used the `toSeconds` method to still convert back to real seconds. This part will be changed in follow up PRs.

# Tests

Verified locally that the game behave the same.

# Future work

As outlined in #44 the `IComponent` interface also needs to be updated.