### PR TITLE
wip: core::Duration -> TickDuration

### DIFF
--- a/database/bsgo/migrations/103_seed_outpost.up.sql
+++ b/database/bsgo/migrations/103_seed_outpost.up.sql
@@ -1,5 +1,5 @@
 
 INSERT INTO outpost ("faction", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "radius")
-  VALUES ('colonial', 30000.0, 120.0, 4500.0, 100.0, 2.0);
+  VALUES ('colonial', 30000.0, 1.2, 4500.0, 1.0, 2.0);
 INSERT INTO outpost ("faction", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "radius")
-  VALUES ('cylon', 30000.0, 120.0, 4500.0, 100.0, 2.0);
+  VALUES ('cylon', 30000.0, 1.2, 4500.0, 1.0, 2.0);

--- a/database/bsgo/migrations/104_seed_ship.up.sql
+++ b/database/bsgo/migrations/104_seed_ship.up.sql
@@ -1,7 +1,7 @@
 
 -- Viper Mark II
 INSERT INTO ship ("name", "faction", "class", "starting_ship", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "max_acceleration", "max_speed", "radius")
-  VALUES ('Viper Mark II', 'colonial', 'strike', true, 450.0, 3.0, 100.0, 2.0, 5.0, 4.0, 0.5);
+  VALUES ('Viper Mark II', 'colonial', 'strike', true, 450.0, 0.03, 100.0, 0.02, 5.0, 4.0, 0.5);
 
 INSERT INTO ship_price ("ship", "resource", "cost")
   VALUES (
@@ -44,7 +44,7 @@ INSERT INTO ship_slot ("ship", "type", "x_pos", "y_pos", "z_pos")
 
 -- Cylon Raider
 INSERT INTO ship ("name", "faction", "class", "starting_ship", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "max_acceleration", "max_speed", "radius")
-  VALUES ('Cylon Raider', 'cylon', 'strike', true, 450.0, 3.0, 100.0, 2.0, 5.0, 4.0, 0.5);
+  VALUES ('Cylon Raider', 'cylon', 'strike', true, 450.0, 0.03, 100.0, 0.02, 5.0, 4.0, 0.5);
 
 INSERT INTO ship_price ("ship", "resource", "cost")
   VALUES (
@@ -87,7 +87,7 @@ INSERT INTO ship_slot ("ship", "type", "x_pos", "y_pos", "z_pos")
 
 -- Viper Mark VII
 INSERT INTO ship ("name", "faction", "class", "starting_ship", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "max_acceleration", "max_speed", "radius")
-  VALUES ('Viper Mark VII', 'colonial', 'strike', false, 585.0, 4.0, 150.0, 5.0, 4.0, 4.0, 0.5);
+  VALUES ('Viper Mark VII', 'colonial', 'strike', false, 585.0, 0.04, 150.0, 0.05, 4.0, 4.0, 0.5);
 
 INSERT INTO ship_price ("ship", "resource", "cost")
   VALUES (
@@ -142,7 +142,7 @@ INSERT INTO ship_slot ("ship", "type", "x_pos", "y_pos", "z_pos")
 
 -- Cylon War Raider
 INSERT INTO ship ("name", "faction", "class", "starting_ship", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "max_acceleration", "max_speed", "radius")
-  VALUES ('Cylon War Raider', 'cylon', 'strike', false, 585.0, 4.0, 150.0, 5.0, 4.0, 4.0, 0.5);
+  VALUES ('Cylon War Raider', 'cylon', 'strike', false, 585.0, 0.04, 150.0, 0.05, 4.0, 4.0, 0.5);
 
 INSERT INTO ship_price ("ship", "resource", "cost")
   VALUES (
@@ -197,7 +197,7 @@ INSERT INTO ship_slot ("ship", "type", "x_pos", "y_pos", "z_pos")
 
 -- Jotunn
 INSERT INTO ship ("name", "faction", "class", "starting_ship", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "max_acceleration", "max_speed", "radius")
-  VALUES ('Jotunn', 'colonial', 'line', false, 3000.0, 50.0, 500.0, 5.0, 1.0, 2.0, 2.0);
+  VALUES ('Jotunn', 'colonial', 'line', false, 3000.0, 0.5, 500.0, 0.05, 1.0, 2.0, 2.0);
 
 INSERT INTO ship_price ("ship", "resource", "cost")
   VALUES (
@@ -264,7 +264,7 @@ INSERT INTO ship_slot ("ship", "type", "x_pos", "y_pos", "z_pos")
 
 -- Jormung
 INSERT INTO ship ("name", "faction", "class", "starting_ship", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "max_acceleration", "max_speed", "radius")
-  VALUES ('Jormung', 'cylon', 'line', false, 3000.0, 50.0, 500.0, 5.0, 1.0, 2.0, 2.0);
+  VALUES ('Jormung', 'cylon', 'line', false, 3000.0, 0.5, 500.0, 0.05, 1.0, 2.0, 2.0);
 
 INSERT INTO ship_price ("ship", "resource", "cost")
   VALUES (
@@ -331,7 +331,7 @@ INSERT INTO ship_slot ("ship", "type", "x_pos", "y_pos", "z_pos")
 
 -- Vanir
 INSERT INTO ship ("name", "faction", "class", "starting_ship", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "max_acceleration", "max_speed", "radius")
-  VALUES ('Vanir', 'colonial', 'line', false, 2500.0, 35.0, 600.0, 7.0, 1.0, 2.0, 2.0);
+  VALUES ('Vanir', 'colonial', 'line', false, 2500.0, 0.35, 600.0, 0.07, 1.0, 2.0, 2.0);
 
 INSERT INTO ship_price ("ship", "resource", "cost")
   VALUES (
@@ -404,7 +404,7 @@ INSERT INTO ship_slot ("ship", "type", "x_pos", "y_pos", "z_pos")
 
 -- Hel
 INSERT INTO ship ("name", "faction", "class", "starting_ship", "max_hull_points", "hull_points_regen", "max_power_points", "power_points_regen", "max_acceleration", "max_speed", "radius")
-  VALUES ('Hel', 'cylon', 'line', false, 2500.0, 35.0, 600.0, 7.0, 1.0, 2.0, 2.0);
+  VALUES ('Hel', 'cylon', 'line', false, 2500.0, 0.35, 600.0, 0.07, 1.0, 2.0, 2.0);
 
 INSERT INTO ship_price ("ship", "resource", "cost")
   VALUES (

--- a/src/bsgo/components/AIComponent.cc
+++ b/src/bsgo/components/AIComponent.cc
@@ -23,6 +23,6 @@ auto AIComponent::behavior() const -> const INode &
   return *m_behavior;
 }
 
-void AIComponent::update(const float /*elapsedSeconds*/) {}
+void AIComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/AIComponent.hh
+++ b/src/bsgo/components/AIComponent.hh
@@ -15,7 +15,7 @@ class AIComponent : public AbstractComponent
   auto behavior() -> INode &;
   auto behavior() const -> const INode &;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   INodePtr m_behavior;

--- a/src/bsgo/components/DamageComponent.cc
+++ b/src/bsgo/components/DamageComponent.cc
@@ -13,6 +13,6 @@ auto DamageComponent::damage() const noexcept -> float
   return m_damage;
 }
 
-void DamageComponent::update(const float /*elapsedSeconds*/) {}
+void DamageComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/DamageComponent.hh
+++ b/src/bsgo/components/DamageComponent.hh
@@ -13,7 +13,7 @@ class DamageComponent : public AbstractComponent
 
   auto damage() const noexcept -> float;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   float m_damage;

--- a/src/bsgo/components/DbComponent.cc
+++ b/src/bsgo/components/DbComponent.cc
@@ -13,6 +13,6 @@ auto DbComponent::dbId() const noexcept -> Uuid
   return m_dbId;
 }
 
-void DbComponent::update(const float /*elapsedSeconds*/) {}
+void DbComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/DbComponent.hh
+++ b/src/bsgo/components/DbComponent.hh
@@ -14,7 +14,7 @@ class DbComponent : public AbstractComponent
 
   auto dbId() const noexcept -> Uuid;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   Uuid m_dbId{};

--- a/src/bsgo/components/EffectComponent.cc
+++ b/src/bsgo/components/EffectComponent.cc
@@ -12,10 +12,7 @@ EffectComponent::EffectComponent(const ComponentType &type, const TickDuration &
 
 bool EffectComponent::isFinished() const
 {
-  // TODO: We should not convert to milliseconds here.
-  constexpr auto MILLI_IN_ONE_SECOND = 1000.0f;
-  const auto durationAsTime = core::toMilliseconds(MILLI_IN_ONE_SECOND * m_duration.toSeconds());
-  return durationAsTime < m_elapsedSinceStart;
+  return m_duration < m_elapsedSinceStart;
 }
 
 auto EffectComponent::damageModifier() const -> std::optional<float>
@@ -23,11 +20,9 @@ auto EffectComponent::damageModifier() const -> std::optional<float>
   return {};
 }
 
-void EffectComponent::update(const float elapsedSeconds)
+void EffectComponent::update(const TickData &data)
 {
-  constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
-  m_elapsedSinceStart += core::Milliseconds(
-    static_cast<int>(elapsedSeconds * MILLISECONDS_IN_A_SECONDS));
+  m_elapsedSinceStart += data.elapsed;
 }
 
 } // namespace bsgo

--- a/src/bsgo/components/EffectComponent.hh
+++ b/src/bsgo/components/EffectComponent.hh
@@ -3,7 +3,6 @@
 
 #include "AbstractComponent.hh"
 #include "TickDuration.hh"
-#include "TimeUtils.hh"
 #include <optional>
 
 namespace bsgo {
@@ -18,11 +17,11 @@ class EffectComponent : public AbstractComponent
 
   virtual auto damageModifier() const -> std::optional<float>;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   TickDuration m_duration;
-  core::Duration m_elapsedSinceStart{};
+  TickDuration m_elapsedSinceStart{};
 };
 
 using EffectComponentShPtr = std::shared_ptr<EffectComponent>;

--- a/src/bsgo/components/FactionComponent.cc
+++ b/src/bsgo/components/FactionComponent.cc
@@ -13,6 +13,6 @@ auto FactionComponent::faction() const noexcept -> Faction
   return m_faction;
 }
 
-void FactionComponent::update(const float /*elapsedSeconds*/) {}
+void FactionComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/FactionComponent.hh
+++ b/src/bsgo/components/FactionComponent.hh
@@ -14,7 +14,7 @@ class FactionComponent : public AbstractComponent
 
   auto faction() const noexcept -> Faction;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   Faction m_faction;

--- a/src/bsgo/components/IComponent.hh
+++ b/src/bsgo/components/IComponent.hh
@@ -3,6 +3,7 @@
 
 #include "ComponentType.hh"
 #include "CoreObject.hh"
+#include "TickData.hh"
 #include <memory>
 
 namespace bsgo {
@@ -15,7 +16,7 @@ class IComponent : public core::CoreObject
 
   virtual auto type() const -> ComponentType = 0;
 
-  virtual void update(const float elapsedSeconds) = 0;
+  virtual void update(const TickData &data) = 0;
 };
 
 using IComponentShPtr = std::shared_ptr<IComponent>;

--- a/src/bsgo/components/KindComponent.cc
+++ b/src/bsgo/components/KindComponent.cc
@@ -13,6 +13,6 @@ auto KindComponent::kind() const noexcept -> EntityKind
   return m_kind;
 }
 
-void KindComponent::update(const float /*elapsedSeconds*/) {}
+void KindComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/KindComponent.hh
+++ b/src/bsgo/components/KindComponent.hh
@@ -14,7 +14,7 @@ class KindComponent : public AbstractComponent
 
   auto kind() const noexcept -> EntityKind;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   EntityKind m_kind;

--- a/src/bsgo/components/LootComponent.cc
+++ b/src/bsgo/components/LootComponent.cc
@@ -22,6 +22,6 @@ void LootComponent::clearRecipients()
   m_recipients.clear();
 }
 
-void LootComponent::update(const float /*elapsedSeconds*/) {}
+void LootComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/LootComponent.hh
+++ b/src/bsgo/components/LootComponent.hh
@@ -18,7 +18,7 @@ class LootComponent : public AbstractComponent
   auto recipients() const -> std::unordered_set<Uuid>;
   void clearRecipients();
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   std::unordered_set<Uuid> m_recipients{};

--- a/src/bsgo/components/NameComponent.cc
+++ b/src/bsgo/components/NameComponent.cc
@@ -13,6 +13,6 @@ auto NameComponent::name() const noexcept -> std::string
   return m_name;
 }
 
-void NameComponent::update(const float /*elapsedSeconds*/) {}
+void NameComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/NameComponent.hh
+++ b/src/bsgo/components/NameComponent.hh
@@ -13,7 +13,7 @@ class NameComponent : public AbstractComponent
 
   auto name() const noexcept -> std::string;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   std::string m_name{};

--- a/src/bsgo/components/OwnerComponent.cc
+++ b/src/bsgo/components/OwnerComponent.cc
@@ -19,6 +19,6 @@ auto OwnerComponent::category() const -> OwnerType
   return m_ownerType;
 }
 
-void OwnerComponent::update(const float /*elapsedSeconds*/) {}
+void OwnerComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/OwnerComponent.hh
+++ b/src/bsgo/components/OwnerComponent.hh
@@ -22,7 +22,7 @@ class OwnerComponent : public AbstractComponent
   auto owner() const -> Uuid;
   auto category() const -> OwnerType;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   Uuid m_owner;

--- a/src/bsgo/components/RegenerativeComponent.cc
+++ b/src/bsgo/components/RegenerativeComponent.cc
@@ -8,19 +8,19 @@ RegenerativeComponent::RegenerativeComponent(const ComponentType &type,
                                              const float min,
                                              const float value,
                                              const float max,
-                                             const float regenPerSecond)
+                                             const float regenPerTick)
   : AbstractComponent(type)
   , m_min(min)
   , m_value(value)
   , m_max(max)
-  , m_regenPerSecond(regenPerSecond)
+  , m_regenPerTick(regenPerTick)
 {
   validate();
 }
 
-void RegenerativeComponent::update(const float elapsedSeconds)
+void RegenerativeComponent::update(const TickData &data)
 {
-  const auto updated = m_value + m_regenPerSecond * elapsedSeconds;
+  const auto updated = m_value + m_regenPerTick * data.elapsed;
   m_value            = std::clamp(updated, m_min, m_max);
 }
 
@@ -66,9 +66,9 @@ void RegenerativeComponent::validate()
     throw std::invalid_argument("Expected value (" + std::to_string(m_value)
                                 + ") to be smaller than max (" + std::to_string(m_max) + ")");
   }
-  if (m_regenPerSecond < 0.0f)
+  if (m_regenPerTick < 0.0f)
   {
-    throw std::invalid_argument("Expected regeneration (" + std::to_string(m_regenPerSecond)
+    throw std::invalid_argument("Expected regeneration (" + std::to_string(m_regenPerTick)
                                 + ") to be greater than 0");
   }
 }

--- a/src/bsgo/components/RegenerativeComponent.hh
+++ b/src/bsgo/components/RegenerativeComponent.hh
@@ -12,10 +12,10 @@ class RegenerativeComponent : public AbstractComponent
                         const float min,
                         const float value,
                         const float max,
-                        const float regenPerSecond);
+                        const float regenPerTick);
   ~RegenerativeComponent() override = default;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   auto min() const -> float;
   auto value() const -> float;
@@ -31,7 +31,7 @@ class RegenerativeComponent : public AbstractComponent
   float m_value;
   float m_max;
 
-  float m_regenPerSecond;
+  float m_regenPerTick;
 
   void validate();
 };

--- a/src/bsgo/components/RemovalComponent.cc
+++ b/src/bsgo/components/RemovalComponent.cc
@@ -17,6 +17,6 @@ bool RemovalComponent::toBeDeleted() const
   return m_markedForRemoval;
 }
 
-void RemovalComponent::update(const float /*elapsedSeconds*/) {}
+void RemovalComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/RemovalComponent.hh
+++ b/src/bsgo/components/RemovalComponent.hh
@@ -14,7 +14,7 @@ class RemovalComponent : public AbstractComponent
   void markForRemoval(const bool toRemove = true);
   bool toBeDeleted() const;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   bool m_markedForRemoval{false};

--- a/src/bsgo/components/ResourceComponent.cc
+++ b/src/bsgo/components/ResourceComponent.cc
@@ -19,7 +19,7 @@ auto ResourceComponent::amount() const -> int
   return m_amount;
 }
 
-void ResourceComponent::update(const float /*elapsedSeconds*/) {}
+void ResourceComponent::update(const TickData & /*data*/) {}
 
 void ResourceComponent::setAmount(const int amount)
 {

--- a/src/bsgo/components/ResourceComponent.hh
+++ b/src/bsgo/components/ResourceComponent.hh
@@ -15,7 +15,7 @@ class ResourceComponent : public AbstractComponent
   auto resource() const -> Uuid;
   auto amount() const -> int;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   void setAmount(const int amount);
 

--- a/src/bsgo/components/ScannedComponent.cc
+++ b/src/bsgo/components/ScannedComponent.cc
@@ -22,6 +22,6 @@ void ScannedComponent::reset()
   m_scanned = false;
 }
 
-void ScannedComponent::update(const float /*elapsedSeconds*/) {}
+void ScannedComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/ScannedComponent.hh
+++ b/src/bsgo/components/ScannedComponent.hh
@@ -15,7 +15,7 @@ class ScannedComponent : public AbstractComponent
   void scan();
   void reset();
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   bool m_scanned{false};

--- a/src/bsgo/components/ShipClassComponent.cc
+++ b/src/bsgo/components/ShipClassComponent.cc
@@ -13,6 +13,6 @@ auto ShipClassComponent::shipClass() const noexcept -> ShipClass
   return m_shipClass;
 }
 
-void ShipClassComponent::update(const float /*elapsedSeconds*/) {}
+void ShipClassComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/ShipClassComponent.hh
+++ b/src/bsgo/components/ShipClassComponent.hh
@@ -14,7 +14,7 @@ class ShipClassComponent : public AbstractComponent
 
   auto shipClass() const noexcept -> ShipClass;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   ShipClass m_shipClass;

--- a/src/bsgo/components/SlotComponent.hh
+++ b/src/bsgo/components/SlotComponent.hh
@@ -34,7 +34,7 @@ class SlotComponent : public AbstractComponent
   SlotComponent(const ComponentType &type, const SlotComponentData &data);
   ~SlotComponent() override = default;
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   auto dbId() const -> Uuid;
   bool isOffensive() const;
@@ -47,7 +47,6 @@ class SlotComponent : public AbstractComponent
   auto reloadPercentage() const -> float;
   auto elapsedSinceLastFired() const -> std::optional<core::Duration>;
 
-  void overrideElapsedSinceLastFired(const std::optional<core::Duration> &elapsed);
   void setFiringState(const FiringState &firingState);
   void registerFireRequest();
   bool hasFireRequest() const;
@@ -63,9 +62,9 @@ class SlotComponent : public AbstractComponent
 
   bool m_fireRequest{false};
   FiringState m_firingState{FiringState::READY};
-  std::optional<core::Duration> m_elapsedSinceLastFired{};
+  std::optional<TickDuration> m_elapsedSinceLastFired{};
 
-  void handleReload(const float elapsedSeconds);
+  void handleReload(const TickData &data);
 };
 
 } // namespace bsgo

--- a/src/bsgo/components/StatusComponent.cc
+++ b/src/bsgo/components/StatusComponent.cc
@@ -4,8 +4,8 @@
 namespace bsgo {
 
 StatusComponent::StatusComponent(const Status &status,
-                                 const std::optional<core::Duration> &jumpTime,
-                                 const std::optional<core::Duration> &threatJumpTime)
+                                 const std::optional<TickDuration> &jumpTime,
+                                 const std::optional<TickDuration> &threatJumpTime)
   : AbstractComponent(ComponentType::STATUS)
   , m_status(status)
   , m_jumpTime(jumpTime)
@@ -31,7 +31,12 @@ auto StatusComponent::jumpTime() const -> core::Duration
   {
     error("Failed to get jump time", "No such value");
   }
-  return *m_jumpTime;
+
+  // TODO: Should not convert back to real time.
+  constexpr auto MILLIS_IN_ONE_SECOND = 1000.0f;
+  const auto jumpTime = core::toMilliseconds(MILLIS_IN_ONE_SECOND * m_jumpTime->toSeconds());
+
+  return jumpTime;
 }
 
 auto StatusComponent::threatJumpTime() const -> core::Duration
@@ -40,7 +45,13 @@ auto StatusComponent::threatJumpTime() const -> core::Duration
   {
     error("Failed to get threat jump time", "No such value");
   }
-  return *m_threatJumpTime;
+
+  // TODO: Should not convert back to real time.
+  constexpr auto MILLIS_IN_ONE_SECOND = 1000.0f;
+  const auto threatJumpTime           = core::toMilliseconds(MILLIS_IN_ONE_SECOND
+                                                   * m_threatJumpTime->toSeconds());
+
+  return threatJumpTime;
 }
 
 bool StatusComponent::justChanged() const
@@ -55,41 +66,38 @@ void StatusComponent::resetChanged()
 
 void StatusComponent::resetAppearingTime()
 {
-  m_elapsedSinceAppearing = core::Duration{0};
+  m_elapsedSinceAppearing = TickDuration();
 }
 
 auto StatusComponent::getElapsedSinceLastChange() const -> core::Duration
 {
-  return m_elapsedSinceLastChange;
+  // TODO: Should not convert back to real time.
+  constexpr auto MILLIS_IN_ONE_SECOND = 1000.0f;
+  const auto elapsed                  = core::toMilliseconds(MILLIS_IN_ONE_SECOND
+                                            * m_elapsedSinceLastChange.toSeconds());
+
+  return elapsed;
 }
 
 auto StatusComponent::tryGetElapsedSinceLastAppearing() const -> std::optional<core::Duration>
 {
-  return m_elapsedSinceAppearing;
-}
-
-auto StatusComponent::tryGetCurrentJumpTime() const -> core::Duration
-{
-  if (!m_currentJumpTime)
+  if (m_elapsedSinceAppearing)
   {
-    error("Failed to get current jump time", "No such value");
+    // TODO: Should not convert back to real time.
+    constexpr auto MILLIS_IN_ONE_SECOND = 1000.0f;
+    const auto elapsed                  = core::toMilliseconds(MILLIS_IN_ONE_SECOND
+                                              * m_elapsedSinceAppearing->toSeconds());
+
+    return elapsed;
   }
-  return *m_currentJumpTime;
+
+  return {};
 }
 
-auto StatusComponent::tryGetElapsedSinceJumpStarted() const -> core::Duration
+auto StatusComponent::getRemainingJumpTime() const -> TickDuration
 {
-  if (!m_elapsedSinceJumpStarted)
-  {
-    error("Failed to get elapsed since jump", "No such value");
-  }
-  return *m_elapsedSinceJumpStarted;
-}
-
-auto StatusComponent::tryGetRemainingJumpTime() const -> core::Duration
-{
-  const auto jumpTime = tryGetCurrentJumpTime();
-  const auto elapsed  = tryGetElapsedSinceJumpStarted();
+  const auto jumpTime = getCurrentJumpTime();
+  const auto elapsed  = getElapsedSinceJumpStarted();
 
   return jumpTime - elapsed;
 }
@@ -101,23 +109,19 @@ void StatusComponent::setStatus(const Status &status)
 
   m_status                 = status;
   m_justChanged            = true;
-  m_elapsedSinceLastChange = core::Duration{0};
+  m_elapsedSinceLastChange = TickDuration();
 }
 
-void StatusComponent::update(const float elapsedSeconds)
+void StatusComponent::update(const TickData &data)
 {
-  constexpr auto MILLISECONDS_IN_A_SECONDS = 1000;
-  const auto elapsedMillis                 = core::Milliseconds(
-    static_cast<int>(elapsedSeconds * MILLISECONDS_IN_A_SECONDS));
-
-  m_elapsedSinceLastChange += elapsedMillis;
+  m_elapsedSinceLastChange += data.elapsed;
   if (m_elapsedSinceAppearing)
   {
-    *m_elapsedSinceAppearing += elapsedMillis;
+    *m_elapsedSinceAppearing += data.elapsed;
   }
   if (m_elapsedSinceJumpStarted)
   {
-    *m_elapsedSinceJumpStarted += elapsedMillis;
+    *m_elapsedSinceJumpStarted += data.elapsed;
   }
 }
 
@@ -132,7 +136,7 @@ void StatusComponent::updateJumpState(const Status &newStatus, const bool forceU
   const auto isJumping  = statusIndicatesJump(newStatus);
   if (!wasJumping && isJumping)
   {
-    m_elapsedSinceJumpStarted = core::Duration{0};
+    m_elapsedSinceJumpStarted = TickDuration();
     m_currentJumpTime         = statusIndicatesThreat(m_status) ? *m_threatJumpTime : *m_jumpTime;
   }
   if (wasJumping && !isJumping)
@@ -151,8 +155,26 @@ void StatusComponent::updateAppearingState(const Status &newStatus)
 
   if (statusIndicatesAppearing(newStatus))
   {
-    m_elapsedSinceAppearing = core::Duration{0};
+    m_elapsedSinceAppearing = TickDuration();
   }
+}
+
+auto StatusComponent::getCurrentJumpTime() const -> TickDuration
+{
+  if (!m_currentJumpTime)
+  {
+    error("Failed to get current jump time", "No such value");
+  }
+  return *m_currentJumpTime;
+}
+
+auto StatusComponent::getElapsedSinceJumpStarted() const -> TickDuration
+{
+  if (!m_elapsedSinceJumpStarted)
+  {
+    error("Failed to get elapsed since jump", "No such value");
+  }
+  return *m_elapsedSinceJumpStarted;
 }
 
 } // namespace bsgo

--- a/src/bsgo/components/StatusComponent.hh
+++ b/src/bsgo/components/StatusComponent.hh
@@ -12,8 +12,8 @@ class StatusComponent : public AbstractComponent
 {
   public:
   StatusComponent(const Status &status,
-                  const std::optional<core::Duration> &jumpTime,
-                  const std::optional<core::Duration> &threatJumpTime);
+                  const std::optional<TickDuration> &jumpTime,
+                  const std::optional<TickDuration> &threatJumpTime);
   ~StatusComponent() = default;
 
   auto status() const -> Status;
@@ -25,26 +25,27 @@ class StatusComponent : public AbstractComponent
   void resetAppearingTime();
   auto getElapsedSinceLastChange() const -> core::Duration;
   auto tryGetElapsedSinceLastAppearing() const -> std::optional<core::Duration>;
-  auto tryGetCurrentJumpTime() const -> core::Duration;
-  auto tryGetElapsedSinceJumpStarted() const -> core::Duration;
-  auto tryGetRemainingJumpTime() const -> core::Duration;
+  auto getRemainingJumpTime() const -> TickDuration;
 
   void setStatus(const Status &status);
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   Status m_status;
-  std::optional<core::Duration> m_jumpTime{};
-  std::optional<core::Duration> m_threatJumpTime{};
+  std::optional<TickDuration> m_jumpTime{};
+  std::optional<TickDuration> m_threatJumpTime{};
   bool m_justChanged{false};
-  core::Duration m_elapsedSinceLastChange{};
-  std::optional<core::Duration> m_elapsedSinceAppearing{};
-  std::optional<core::Duration> m_elapsedSinceJumpStarted{};
-  std::optional<core::Duration> m_currentJumpTime{};
+  TickDuration m_elapsedSinceLastChange{};
+  std::optional<TickDuration> m_elapsedSinceAppearing{};
+  std::optional<TickDuration> m_elapsedSinceJumpStarted{};
+  std::optional<TickDuration> m_currentJumpTime{};
 
   void updateJumpState(const Status &newStatus, const bool forceUpdate);
   void updateAppearingState(const Status &newStatus);
+
+  auto getCurrentJumpTime() const -> TickDuration;
+  auto getElapsedSinceJumpStarted() const -> TickDuration;
 };
 
 using StatusComponentShPtr = std::shared_ptr<StatusComponent>;

--- a/src/bsgo/components/SyncComponent.hh
+++ b/src/bsgo/components/SyncComponent.hh
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "AbstractComponent.hh"
-#include "TimeUtils.hh"
+#include "TickDuration.hh"
 
 namespace bsgo {
 
@@ -17,11 +17,12 @@ class SyncComponent : public AbstractComponent
   void markForSync(const bool needsSync = true);
   void markAsJustSynced();
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   bool m_needsSync{false};
-  core::Duration m_remainingUntilNextSync{};
+  TickDuration m_untilNextSync{};
+  TickDuration m_elapsedSinceLastSync{};
 };
 
 } // namespace bsgo

--- a/src/bsgo/components/TargetComponent.cc
+++ b/src/bsgo/components/TargetComponent.cc
@@ -27,6 +27,6 @@ void TargetComponent::setTarget(const Uuid target)
   m_target = target;
 }
 
-void TargetComponent::update(const float /*elapsedSeconds*/) {}
+void TargetComponent::update(const TickData & /*data*/) {}
 
 } // namespace bsgo

--- a/src/bsgo/components/TargetComponent.hh
+++ b/src/bsgo/components/TargetComponent.hh
@@ -18,7 +18,7 @@ class TargetComponent : public AbstractComponent
   void clearTarget();
   void setTarget(const Uuid target);
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   std::optional<Uuid> m_target{};

--- a/src/bsgo/components/TransformComponent.cc
+++ b/src/bsgo/components/TransformComponent.cc
@@ -64,7 +64,7 @@ void TransformComponent::setHeading(const float heading)
   m_heading = heading;
 }
 
-void TransformComponent::update(const float /*elapsedSeconds*/) {}
+void TransformComponent::update(const TickData & /*data*/) {}
 
 namespace {
 const Eigen::Vector3f Z_AXIS = Eigen::Vector3f(0.0, 0.0, 1.0);

--- a/src/bsgo/components/TransformComponent.hh
+++ b/src/bsgo/components/TransformComponent.hh
@@ -21,7 +21,7 @@ class TransformComponent : public AbstractComponent
   void overridePosition(const Eigen::Vector3f &position);
   void setHeading(const float heading);
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   auto transformToGlobal(const Eigen::Vector3f &localPos) const -> Eigen::Vector3f;
 

--- a/src/bsgo/components/VelocityComponent.cc
+++ b/src/bsgo/components/VelocityComponent.cc
@@ -56,15 +56,15 @@ void VelocityComponent::immobilize()
   m_speed        = Eigen::Vector3f::Zero();
 }
 
-void VelocityComponent::update(const float elapsedSeconds)
+void VelocityComponent::update(const TickData &data)
 {
   switch (m_speedMode)
   {
     case SpeedMode::FIXED:
-      updateFixedSpeed(elapsedSeconds);
+      updateFixedSpeed(data);
       break;
     case SpeedMode::VARIABLE:
-      updateVariableSpeed(elapsedSeconds);
+      updateVariableSpeed(data);
       break;
     default:
       error("Failed to updated velocity",
@@ -73,17 +73,19 @@ void VelocityComponent::update(const float elapsedSeconds)
   }
 }
 
-void VelocityComponent::updateFixedSpeed(const float /*elapsedSeconds*/)
+void VelocityComponent::updateFixedSpeed(const TickData & /*data*/)
 {
-  // Intentionally empty.
+  // Intentionally empty: fixed speed means no update to the speed.
 }
 
-void VelocityComponent::updateVariableSpeed(const float elapsedSeconds)
+void VelocityComponent::updateVariableSpeed(const TickData &data)
 {
-  /// https://gamedev.stackexchange.com/questions/69404/how-should-i-implement-basic-spaceship-physics
-  m_speed += m_acceleration * elapsedSeconds;
+  // TODO: This could be improved.
+  const auto elapsed = 1.0f * data.elapsed;
+  // https://gamedev.stackexchange.com/questions/69404/how-should-i-implement-basic-spaceship-physics
+  m_speed += m_acceleration * elapsed;
 
-  Eigen::Vector3f friction = -FRICTION_ACCELERATION * elapsedSeconds * m_speed.normalized();
+  Eigen::Vector3f friction = -FRICTION_ACCELERATION * elapsed * m_speed.normalized();
   m_speed += friction;
 
   const auto speedNorm = m_speed.norm();

--- a/src/bsgo/components/VelocityComponent.hh
+++ b/src/bsgo/components/VelocityComponent.hh
@@ -54,7 +54,7 @@ class VelocityComponent : public AbstractComponent
 
   void immobilize();
 
-  void update(const float elapsedSeconds) override;
+  void update(const TickData &data) override;
 
   private:
   SpeedMode m_speedMode;
@@ -64,8 +64,8 @@ class VelocityComponent : public AbstractComponent
   Eigen::Vector3f m_acceleration{Eigen::Vector3f::Zero()};
   Eigen::Vector3f m_speed{Eigen::Vector3f::Zero()};
 
-  void updateFixedSpeed(const float elapsedSeconds);
-  void updateVariableSpeed(const float elapsedSeconds);
+  void updateFixedSpeed(const TickData &data);
+  void updateVariableSpeed(const TickData &data);
 };
 
 using VelocityComponentShPtr = std::shared_ptr<VelocityComponent>;

--- a/src/bsgo/controller/Coordinator.cc
+++ b/src/bsgo/controller/Coordinator.cc
@@ -144,8 +144,8 @@ void Coordinator::addRemoval(const Uuid ent)
 
 void Coordinator::addStatus(const Uuid ent,
                             const Status &status,
-                            const std::optional<core::Duration> &jumpTime,
-                            const std::optional<core::Duration> &threatJumpTime)
+                            const std::optional<TickDuration> &jumpTime,
+                            const std::optional<TickDuration> &threatJumpTime)
 {
   checkForOverrides(ent, "Status", m_components.statuses);
   m_components.statuses[ent] = std::make_shared<StatusComponent>(status, jumpTime, threatJumpTime);

--- a/src/bsgo/controller/Coordinator.hh
+++ b/src/bsgo/controller/Coordinator.hh
@@ -11,7 +11,6 @@
 #include "Systems.hh"
 #include "TickData.hh"
 #include "TickDuration.hh"
-#include "TimeUtils.hh"
 #include "Uuid.hh"
 #include <eigen3/Eigen/Eigen>
 #include <memory>
@@ -44,8 +43,8 @@ class Coordinator : public core::CoreObject
   void addRemoval(const Uuid ent);
   void addStatus(const Uuid ent,
                  const Status &status,
-                 const std::optional<core::Duration> &jumpTime,
-                 const std::optional<core::Duration> &threatJumpTime);
+                 const std::optional<TickDuration> &jumpTime,
+                 const std::optional<TickDuration> &threatJumpTime);
   void addAI(const Uuid ent, INodePtr behavior);
   void addShipClass(const Uuid ent, const ShipClass &shipClass);
   void addName(const Uuid ent, const std::string &name);

--- a/src/bsgo/data/ShipDataSource.cc
+++ b/src/bsgo/data/ShipDataSource.cc
@@ -67,12 +67,7 @@ void ShipDataSource::registerShip(Coordinator &coordinator,
   coordinator.addHealth(shipEntityId, data.hullPoints, data.maxHullPoints, data.hullPointsRegen);
   coordinator.addPower(shipEntityId, data.powerPoints, data.maxPowerPoints, data.powerRegen);
   coordinator.addFaction(shipEntityId, data.faction);
-  // TODO: Replace this to not convert back to a time.
-  constexpr auto MILLIS_IN_ONE_SECOND = 1000.0f;
-  const auto jumpTime = core::toMilliseconds(MILLIS_IN_ONE_SECOND * data.jumpTime.toSeconds());
-  const auto jumpTimeInThreat = core::toMilliseconds(MILLIS_IN_ONE_SECOND
-                                                     * data.jumpTimeInThreat.toSeconds());
-  coordinator.addStatus(shipEntityId, data.status, jumpTime, jumpTimeInThreat);
+  coordinator.addStatus(shipEntityId, data.status, data.jumpTime, data.jumpTimeInThreat);
   coordinator.addShipClass(shipEntityId, data.shipClass);
   coordinator.addName(shipEntityId, data.name);
   if (data.targetDbId)

--- a/src/bsgo/systems/AISystem.cc
+++ b/src/bsgo/systems/AISystem.cc
@@ -16,8 +16,7 @@ AISystem::AISystem()
 void AISystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &aiComp = entity.aiComp();
-  // TODO: We should use the tick duration as is.
-  aiComp.update(data.elapsed.toSeconds());
+  aiComp.update(data);
 
   BehaviorData aiData{.ent = entity, .coordinator = coordinator};
   aiComp.behavior().tick(aiData);

--- a/src/bsgo/systems/ComputerSystem.cc
+++ b/src/bsgo/systems/ComputerSystem.cc
@@ -60,8 +60,7 @@ void ComputerSystem::updateComputer(const Entity &ent,
 {
   auto state{FiringState::READY};
 
-  // TODO: We should use the tick duration as is.
-  computer->update(data.elapsed.toSeconds());
+  computer->update(data);
 
   if (computer->isOffensive() && (!target.has_value() || !isValidTarget(ent, *target, *computer)))
   {

--- a/src/bsgo/systems/EffectSystem.cc
+++ b/src/bsgo/systems/EffectSystem.cc
@@ -18,8 +18,7 @@ void EffectSystem::updateEntity(Entity &entity, Coordinator &coordinator, const 
 {
   for (const auto &effect : entity.effects)
   {
-    // TODO: We should use the tick duration as is.
-    effect->update(data.elapsed.toSeconds());
+    effect->update(data);
   }
 
   cleanUpFinishedEffects(entity, coordinator);

--- a/src/bsgo/systems/HealthSystem.cc
+++ b/src/bsgo/systems/HealthSystem.cc
@@ -26,8 +26,7 @@ void HealthSystem::updateEntity(Entity &entity,
 
   if (canRegenerateHealth(entity))
   {
-    // TODO: We should use the tick duration as is.
-    entity.healthComp().update(data.elapsed.toSeconds());
+    entity.healthComp().update(data);
   }
 }
 

--- a/src/bsgo/systems/LootSystem.cc
+++ b/src/bsgo/systems/LootSystem.cc
@@ -17,8 +17,7 @@ LootSystem::LootSystem()
 
 void LootSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
-  // TODO: We should use the tick duration as is.
-  entity.lootComp().update(data.elapsed.toSeconds());
+  entity.lootComp().update(data);
 
   const auto &health = entity.healthComp();
   if (health.isAlive())

--- a/src/bsgo/systems/MotionSystem.cc
+++ b/src/bsgo/systems/MotionSystem.cc
@@ -20,8 +20,7 @@ void MotionSystem::updateEntity(Entity &entity,
   auto &velocity  = entity.velocityComp();
   auto &transform = entity.transformComp();
 
-  // TODO: We should use the tick duration as is.
-  velocity.update(data.elapsed.toSeconds());
+  velocity.update(data);
 
   const Eigen::Vector3f speed = velocity.speed();
   // TODO: We should use the tick duration as is.

--- a/src/bsgo/systems/NetworkSystem.cc
+++ b/src/bsgo/systems/NetworkSystem.cc
@@ -19,8 +19,7 @@ void NetworkSystem::updateEntity(Entity &entity,
                                  const TickData &data) const
 {
   auto &networkSyncComp = entity.networkSyncComp();
-  // TODO: We should use the tick duration as is.
-  networkSyncComp.update(data.elapsed.toSeconds());
+  networkSyncComp.update(data);
 
   if (!networkSyncComp.needsSync())
   {

--- a/src/bsgo/systems/PowerSystem.cc
+++ b/src/bsgo/systems/PowerSystem.cc
@@ -19,8 +19,7 @@ void PowerSystem::updateEntity(Entity &entity,
 {
   if (canRegeneratePower(entity))
   {
-    // TODO: We should use the tick duration as is.
-    entity.powerComp().update(data.elapsed.toSeconds());
+    entity.powerComp().update(data);
   }
 }
 

--- a/src/bsgo/systems/RemovalSystem.cc
+++ b/src/bsgo/systems/RemovalSystem.cc
@@ -19,8 +19,7 @@ void RemovalSystem::updateEntity(Entity &entity,
                                  Coordinator & /*coordinator*/,
                                  const TickData &data) const
 {
-  // TODO: We should use the tick duration as is.
-  entity.removalComp().update(data.elapsed.toSeconds());
+  entity.removalComp().update(data);
 
   auto removalFromStatus{false};
   if (entity.exists<StatusComponent>())

--- a/src/bsgo/systems/StatusSystem.cc
+++ b/src/bsgo/systems/StatusSystem.cc
@@ -21,8 +21,7 @@ constexpr auto TIME_TO_STAY_IN_THREAT_MODE   = core::Milliseconds{3'000};
 void StatusSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &statusComp = entity.statusComp();
-  // TODO: We should use the tick duration as is.
-  statusComp.update(data.elapsed.toSeconds());
+  statusComp.update(data);
 
   handleAppearingState(entity, statusComp);
   handleThreatState(entity, statusComp);
@@ -96,8 +95,8 @@ void StatusSystem::handleJumpState(Entity &entity,
     return;
   }
 
-  const auto remaining = statusComp.tryGetRemainingJumpTime();
-  if (remaining >= core::Duration{0})
+  const auto remaining = statusComp.getRemainingJumpTime();
+  if (remaining > TickDuration())
   {
     return;
   }

--- a/src/bsgo/systems/TargetSystem.cc
+++ b/src/bsgo/systems/TargetSystem.cc
@@ -17,8 +17,7 @@ TargetSystem::TargetSystem()
 void TargetSystem::updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const
 {
   auto &targetComp = entity.targetComp();
-  // TODO: We should use the tick duration as is.
-  targetComp.update(data.elapsed.toSeconds());
+  targetComp.update(data);
 
   if (!targetComp.target())
   {

--- a/src/bsgo/systems/WeaponSystem.cc
+++ b/src/bsgo/systems/WeaponSystem.cc
@@ -65,8 +65,7 @@ void WeaponSystem::updateWeapon(const Entity &ent,
 {
   auto state{FiringState::READY};
 
-  // TODO: We should use the tick duration as is.
-  weapon->update(data.elapsed.toSeconds());
+  weapon->update(data);
 
   if (!weapon->active())
   {

--- a/src/bsgo/time/TickDuration.cc
+++ b/src/bsgo/time/TickDuration.cc
@@ -47,6 +47,34 @@ bool TickDuration::operator>=(const TickDuration &rhs) const
   return m_elapsed >= rhs.m_elapsed;
 }
 
+auto TickDuration::operator+=(const TickDuration &duration) -> TickDuration &
+{
+  m_elapsed += duration.m_elapsed;
+  return *this;
+}
+
+auto TickDuration::operator/(const TickDuration &duration) const -> float
+{
+  return m_elapsed / duration.m_elapsed;
+}
+
+auto TickDuration::operator*(const float rhs) const -> float
+{
+  return rhs * m_elapsed;
+}
+
+auto TickDuration::operator-(const TickDuration &rhs) const -> TickDuration
+{
+  const auto duration = m_elapsed - rhs.m_elapsed;
+
+  if (duration < 0.0f)
+  {
+    return TickDuration();
+  }
+
+  return TickDuration(duration);
+}
+
 auto TickDuration::serialize(std::ostream &out) const -> std::ostream &
 {
   core::serialize(out, m_elapsed);
@@ -80,6 +108,11 @@ void TickDuration::validate()
     throw std::invalid_argument("Tick duration cannot be negative, got: "
                                 + std::to_string(m_elapsed));
   }
+}
+
+auto operator*(const float lhs, const TickDuration &rhs) -> float
+{
+  return rhs * lhs;
 }
 
 } // namespace bsgo

--- a/src/bsgo/time/TickDuration.hh
+++ b/src/bsgo/time/TickDuration.hh
@@ -34,6 +34,18 @@ class TickDuration
   bool operator>(const TickDuration &rhs) const;
   bool operator>=(const TickDuration &rhs) const;
 
+  // TODO: Should be tested and documented
+  auto operator+=(const TickDuration &duration) -> TickDuration &;
+
+  // TODO: Should be tested and documented
+  auto operator/(const TickDuration &duration) const -> float;
+
+  // TODO: Should be tested and documented
+  auto operator*(const float rhs) const -> float;
+
+  // TODO: Should be tested and documented
+  auto operator-(const TickDuration &rhs) const -> TickDuration;
+
   auto serialize(std::ostream &out) const -> std::ostream &;
   bool deserialize(std::istream &in);
 
@@ -66,5 +78,8 @@ class TickDuration
 
   void validate();
 };
+
+// TODO: Should be tested and documented
+auto operator*(const float lhs, const TickDuration &rhs) -> float;
 
 } // namespace bsgo

--- a/src/server/lib/game/processes/DbSyncProcess.cc
+++ b/src/server/lib/game/processes/DbSyncProcess.cc
@@ -35,7 +35,8 @@ void DbSyncProcess::updateEntity(Entity &entity,
                                  const float elapsedSeconds) const
 {
   auto &dbSyncComp = entity.dbSyncComp();
-  dbSyncComp.update(elapsedSeconds);
+  // TODO: This should be adpated.
+  // dbSyncComp.update(elapsedSeconds);
 
   if (!dbSyncComp.needsSync())
   {


### PR DESCRIPTION
# Work

In #47 the `IComponent` interface was changed to accept a `TickData` argument in the `update` method. This means that we can now replace the actual business logic to not convert the `TickDuration` contained in it to a real time but directly work with it.

With this change, the game logic will be fully decoupled from real time.

# Tests

:red_circle: 

# Future work

As outlined in #39, we still need to make the client applications aware of the time step so that they can configure the `TimeManager` correctly.
