### PR TITLE
feat: Used TickData in Processes

### DIFF
--- a/src/server/lib/game/SystemProcessor.cc
+++ b/src/server/lib/game/SystemProcessor.cc
@@ -98,11 +98,8 @@ void SystemProcessor::asyncSystemProcessing()
     };
 
     const auto data = m_timeManager->tick(elapsed);
-
     m_coordinator->update(data);
-
-    const auto elapsedSecond = elapsed.convert(chrono::Unit::SECONDS).elapsed;
-    m_processes.update(*m_coordinator, elapsedSecond);
+    m_processes.update(*m_coordinator, data);
     m_inputMessagesQueue->processMessages();
 
     lastFrameTimestamp = thisFrameTimestamp;

--- a/src/server/lib/game/processes/DbSyncProcess.cc
+++ b/src/server/lib/game/processes/DbSyncProcess.cc
@@ -21,21 +21,22 @@ bool entityShouldBeSynced(const Entity &entity)
 }
 } // namespace
 
-void DbSyncProcess::update(Coordinator &coordinator, const float elapsedSeconds) const
+void DbSyncProcess::update(Coordinator &coordinator, const TickData &data) const
 {
   auto entities = coordinator.getEntitiesSatistying(entityShouldBeSynced);
   for (auto &entity : entities)
   {
-    updateEntity(entity, coordinator, elapsedSeconds);
+    updateEntity(entity, coordinator, data);
   }
 }
 
 void DbSyncProcess::updateEntity(Entity &entity,
                                  Coordinator & /*coordinator*/,
-                                 const float elapsedSeconds) const
+                                 const TickData &data) const
 {
   auto &dbSyncComp = entity.dbSyncComp();
-  dbSyncComp.update(elapsedSeconds);
+  // TODO: We should use the tick duration as is.
+  dbSyncComp.update(data.elapsed.toSeconds());
 
   if (!dbSyncComp.needsSync())
   {

--- a/src/server/lib/game/processes/DbSyncProcess.hh
+++ b/src/server/lib/game/processes/DbSyncProcess.hh
@@ -13,12 +13,12 @@ class DbSyncProcess : public AbstractProcess
   DbSyncProcess(const Repositories &repositories);
   ~DbSyncProcess() override = default;
 
-  void update(Coordinator &coordinator, const float elapsedSeconds) const override;
+  void update(Coordinator &coordinator, const TickData &data) const override;
 
   private:
   DatabaseSynchronizer m_synchronizer;
 
-  void updateEntity(Entity &entity, Coordinator &coordinator, const float elapsedSeconds) const;
+  void updateEntity(Entity &entity, Coordinator &coordinator, const TickData &data) const;
 };
 
 } // namespace bsgo

--- a/src/server/lib/game/processes/IProcess.hh
+++ b/src/server/lib/game/processes/IProcess.hh
@@ -3,6 +3,7 @@
 
 #include "CoreObject.hh"
 #include "ProcessType.hh"
+#include "TickData.hh"
 #include <memory>
 
 namespace bsgo {
@@ -17,7 +18,7 @@ class IProcess : public core::CoreObject
 
   virtual auto type() const -> ProcessType = 0;
 
-  virtual void update(Coordinator &coordinator, const float elapsedSeconds) const = 0;
+  virtual void update(Coordinator &coordinator, const TickData &data) const = 0;
 };
 
 using IProcessPtr = std::unique_ptr<IProcess>;

--- a/src/server/lib/game/processes/Processes.cc
+++ b/src/server/lib/game/processes/Processes.cc
@@ -15,11 +15,11 @@ Processes::Processes()
   initialize();
 }
 
-void Processes::update(Coordinator &coordinator, const float elapsedSeconds) const
+void Processes::update(Coordinator &coordinator, const TickData &data) const
 {
   for (const auto &process : m_processes)
   {
-    process->update(coordinator, elapsedSeconds);
+    process->update(coordinator, data);
   }
 }
 

--- a/src/server/lib/game/processes/Processes.hh
+++ b/src/server/lib/game/processes/Processes.hh
@@ -14,7 +14,7 @@ class Processes : public core::CoreObject
   Processes();
   ~Processes() override = default;
 
-  void update(Coordinator &coordinator, const float elapsedSeconds) const;
+  void update(Coordinator &coordinator, const TickData &data) const;
 
   private:
   std::vector<IProcessPtr> m_processes{};

--- a/src/server/lib/game/processes/RespawnProcess.cc
+++ b/src/server/lib/game/processes/RespawnProcess.cc
@@ -7,7 +7,7 @@ RespawnProcess::RespawnProcess(const Repositories &repositories)
   : AbstractProcess(ProcessType::RESPAWN, repositories)
 {}
 
-void RespawnProcess::update(Coordinator &coordinator, const float /*elapsedSeconds*/) const
+void RespawnProcess::update(Coordinator &coordinator, const TickData & /*data*/) const
 {
   respawnAsteroids(coordinator);
 }

--- a/src/server/lib/game/processes/RespawnProcess.hh
+++ b/src/server/lib/game/processes/RespawnProcess.hh
@@ -11,7 +11,7 @@ class RespawnProcess : public AbstractProcess
   RespawnProcess(const Repositories &repositories);
   ~RespawnProcess() override = default;
 
-  void update(Coordinator &coordinator, const float elapsedSeconds) const override;
+  void update(Coordinator &coordinator, const TickData &data) const override;
 
   private:
   void respawnAsteroids(Coordinator &coordinator) const;


### PR DESCRIPTION
# Work

In #44 and #48, the `ISystem` interface was changed to receive `TickData` as input of its `update` method. This is a first step to decouple the game logic from real time.

In this PR, the same changes are applied to the `IProcess` interface: instead of taking the elapsed seconds since the last frame, the `update` method now takes a `TickData` structure as argument.

# Tests

Verified locally that the database sync process still works as expected.

# Future work

With this change we can proceed with #47: the change to the `IComponent` interface will not break the compatibility with the `DbSyncProcess`.
