### PR TITLE
 feat: Added entt through fetch content

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -28,7 +28,7 @@ jobs:
     # https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container#example-running-a-job-within-a-container
     # https://github.com/orgs/community/discussions/26324
     # Need to be kept in sync with the relevant CI docker image
-    container: totocorpsoftwareinc/ci-cpp-build-image:378f409
+    container: totocorpsoftwareinc/ci-cpp-build-image:c53cf28
     steps:
       - uses: actions/checkout@v6
       - name: Restore ccache
@@ -71,7 +71,7 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    container: totocorpsoftwareinc/ci-cpp-build-image:378f409
+    container: totocorpsoftwareinc/ci-cpp-build-image:c53cf28
     needs: [build]
     steps:
       - name: Download build data
@@ -105,7 +105,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
-    container: totocorpsoftwareinc/ci-cpp-build-image:378f409
+    container: totocorpsoftwareinc/ci-cpp-build-image:c53cf28
     needs: [build]
     services:
       postgres:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -28,7 +28,7 @@ jobs:
     # https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container#example-running-a-job-within-a-container
     # https://github.com/orgs/community/discussions/26324
     # Need to be kept in sync with the relevant CI docker image
-    container: totocorpsoftwareinc/ci-cpp-build-image:c53cf28
+    container: totocorpsoftwareinc/ci-cpp-build-image:bfe7dc1
     steps:
       - uses: actions/checkout@v6
       - name: Restore ccache
@@ -71,7 +71,7 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    container: totocorpsoftwareinc/ci-cpp-build-image:c53cf28
+    container: totocorpsoftwareinc/ci-cpp-build-image:bfe7dc1
     needs: [build]
     steps:
       - name: Download build data
@@ -105,7 +105,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
-    container: totocorpsoftwareinc/ci-cpp-build-image:c53cf28
+    container: totocorpsoftwareinc/ci-cpp-build-image:bfe7dc1
     needs: [build]
     services:
       postgres:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include (FetchContent)
 FetchContent_Declare (
 	entt
 	GIT_REPOSITORY https://github.com/skypjack/entt.git
-	GIT_TAG v3.13.2
+	GIT_TAG v3.16.0
 )
 
 FetchContent_MakeAvailable (entt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required (VERSION 3.28)
 
+include (FetchContent)
+
+FetchContent_Declare (
+	entt
+	GIT_REPOSITORY https://github.com/skypjack/entt.git
+	GIT_TAG v3.13.2
+)
+
+FetchContent_MakeAvailable (entt)
+
 option (ENABLE_TESTS "Enable tests" OFF)
 
 # https://stackoverflow.com/questions/66680147/how-to-change-c-version-being-used-by-vs-code

--- a/build/ci-cpp-build-image/Dockerfile
+++ b/build/ci-cpp-build-image/Dockerfile
@@ -49,6 +49,7 @@ RUN cmake \
       -DCMAKE_CXX_STANDARD=${CPP_VERSION} \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=1 \
+      -DSKIP_BUILD_TEST=on \
       .
 RUN cmake --build . -j 8
 RUN cmake --install .

--- a/build/ci-cpp-build-image/Dockerfile
+++ b/build/ci-cpp-build-image/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3=3.12.3-0ubuntu2.1 \
   # https://superuser.com/questions/801159/cannot-decompress-tar-xz-file-getting-xz-cannot-exec-no-such-file-or-direct
   xz-utils=5.6.1+really5.4.5-1ubuntu0.2 \
+  git=1:2.43.0-1ubuntu7.3 \
   && rm -rf /var/lib/apt/lists/*
 # https://www.dedicatedcore.com/blog/install-gcc-compiler-ubuntu/
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13 --slave /usr/bin/g++ g++ /usr/bin/g++-13

--- a/src/bsgalone/core/CMakeLists.txt
+++ b/src/bsgalone/core/CMakeLists.txt
@@ -8,7 +8,15 @@ target_include_directories (bsgalone_core_lib PUBLIC
 	)
 
 add_subdirectory (
+	${CMAKE_CURRENT_SOURCE_DIR}/components
+	)
+
+add_subdirectory (
 	${CMAKE_CURRENT_SOURCE_DIR}/domain
+	)
+
+add_subdirectory (
+	${CMAKE_CURRENT_SOURCE_DIR}/entities
 	)
 
 add_subdirectory (
@@ -18,6 +26,8 @@ add_subdirectory (
 target_link_libraries (bsgalone_core_lib PUBLIC
 	bsgalone-interface-library
 	net_lib
+	time_lib
+	EnTT::EnTT
 	)
 
 if (${ENABLE_TESTS})

--- a/src/bsgalone/core/components/CMakeLists.txt
+++ b/src/bsgalone/core/components/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+target_include_directories (bsgalone_core_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (bsgalone_core_lib PRIVATE
+	)

--- a/src/bsgalone/core/components/FactionComponent.hh
+++ b/src/bsgalone/core/components/FactionComponent.hh
@@ -1,0 +1,13 @@
+
+#pragma once
+
+#include "Faction.hh"
+
+namespace bsgalone::core {
+
+struct FactionComponent
+{
+  Faction faction{};
+};
+
+} // namespace bsgalone::core

--- a/src/bsgalone/core/entities/CMakeLists.txt
+++ b/src/bsgalone/core/entities/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_include_directories (bsgalone_core_lib PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (bsgalone_core_lib PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/EntityRegistry.cc
+	)

--- a/src/bsgalone/core/entities/EntityRegistry.cc
+++ b/src/bsgalone/core/entities/EntityRegistry.cc
@@ -1,0 +1,18 @@
+
+#include "EntityRegistry.hh"
+
+namespace bsgalone::core {
+
+auto EntityRegistry::createEntity() -> Uuid
+{
+  const auto entity = m_registry.create();
+
+  const auto uuid = m_nextEntity;
+  ++m_nextEntity;
+
+  m_entities.emplace(uuid, entity);
+
+  return uuid;
+}
+
+} // namespace bsgalone::core

--- a/src/bsgalone/core/entities/EntityRegistry.hh
+++ b/src/bsgalone/core/entities/EntityRegistry.hh
@@ -1,0 +1,53 @@
+
+#pragma once
+
+#include "Uuid.hh"
+#include <entt/entt.hpp>
+#include <unordered_map>
+
+namespace bsgalone::core {
+
+class EntityRegistry
+{
+  public:
+  EntityRegistry()  = default;
+  ~EntityRegistry() = default;
+
+  /// @brief - Creates a new (empty) entity and returns it. The returned identifier can
+  /// be used later on to modify the entity for example when adding components.
+  /// This is currently not thread-safe.
+  /// @return - the identifier of the entity
+  auto createEntity() -> Uuid;
+
+  /// @brief - Adds a component to the entity. If the entity does not exist, this function
+  /// will raise an error.
+  /// @param entityId - the entity to add the component to
+  /// @param component - the component to add to the entity
+  template<typename Component>
+  void addComponent(const Uuid entityId, Component &&component);
+
+  /// @brief - Applied the function to all the entities having all required components set.
+  /// @tparam ...Components - the required components for an entity to qualify for the
+  /// application of the function
+  /// @tparam Func - the signature of the function: this parameter should be inferred from
+  /// the signature of of the lambda provided and does not need to be provided explicitly
+  /// in general.
+  /// @param modifier - a function to update components. Can be provided as a lambda
+  template<typename... Components, typename Func>
+  void apply(Func &&modifier);
+
+  private:
+  /// @brief - The registry used by entt to store entities.
+  entt::registry m_registry{};
+
+  /// @brief - A table of association between the identifier of the entities as defined
+  /// by `entt` to agnostic identifier that can be communicated to the rest of the app
+  /// without leaking the library details.
+  std::unordered_map<Uuid, entt::entity> m_entities{};
+
+  Uuid m_nextEntity{Uuid(0)};
+};
+
+} // namespace bsgalone::core
+
+#include "EntityRegistry.hxx"

--- a/src/bsgalone/core/entities/EntityRegistry.hxx
+++ b/src/bsgalone/core/entities/EntityRegistry.hxx
@@ -1,0 +1,27 @@
+
+#pragma once
+
+#include "EntityRegistry.hh"
+
+namespace bsgalone::core {
+
+template<typename Component>
+inline void EntityRegistry::addComponent(const Uuid entityId, Component &&component)
+{
+  const auto maybeEntity = m_entities.find(entityId);
+  if (maybeEntity == m_entities.end())
+  {
+    throw std::invalid_argument("No such entity " + str(entityId));
+  }
+
+  m_registry.emplace<Component>(maybeEntity->second, std::forward<Component>(component));
+}
+
+template<typename... Components, typename Func>
+inline void EntityRegistry::apply(Func &&modifier)
+{
+  auto view = m_registry.view<Components...>();
+  view.each(std::forward<Func>(modifier));
+}
+
+} // namespace bsgalone::core

--- a/tests/unit/bsgalone/core/CMakeLists.txt
+++ b/tests/unit/bsgalone/core/CMakeLists.txt
@@ -8,5 +8,9 @@ add_subdirectory (
 	)
 
 add_subdirectory (
+	${CMAKE_CURRENT_SOURCE_DIR}/entities
+	)
+
+add_subdirectory (
 	${CMAKE_CURRENT_SOURCE_DIR}/messages
 	)

--- a/tests/unit/bsgalone/core/entities/CMakeLists.txt
+++ b/tests/unit/bsgalone/core/entities/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_include_directories (unitTests PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}
+	)
+
+target_sources (unitTests PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/EntityRegistryTest.cc
+	)

--- a/tests/unit/bsgalone/core/entities/EntityRegistryTest.cc
+++ b/tests/unit/bsgalone/core/entities/EntityRegistryTest.cc
@@ -1,0 +1,37 @@
+
+#include "EntityRegistry.hh"
+#include "FactionComponent.hh"
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+namespace bsgalone::core {
+
+TEST(Unit_Bsgalone_Core_Entities_EntityRegistry, ThrowsWhenAddingComponentToUnknownEntity)
+{
+  auto code = []() {
+    EntityRegistry registry;
+    FactionComponent component{.faction = Faction::COLONIAL};
+    registry.addComponent(Uuid{17}, std::move(component));
+  };
+  EXPECT_THAT(code, ThrowsMessage<std::invalid_argument>("No such entity 17"));
+}
+
+TEST(Unit_Bsgalone_Core_Entities_EntityRegistry, RegistersComponentForEntity)
+{
+  EntityRegistry registry;
+
+  const auto entityId = registry.createEntity();
+
+  FactionComponent component{.faction = Faction::CYLON};
+  registry.addComponent(entityId, std::move(component));
+
+  int counter = 0;
+  registry.apply<FactionComponent>(
+    [&counter](const FactionComponent & /*component*/) { ++counter; });
+
+  EXPECT_EQ(1, counter);
+}
+
+} // namespace bsgalone::core


### PR DESCRIPTION
# Work

To make the entity component system used through the game a bit more robust, I want to use the [entt](https://github.com/skypjack/entt) library: it's a well established library to handle the EC part of the ECS. The goal is to be able to benefit from the automatic filtering/iterating over entities.

To do so, the easiest way is to use `FetchContent` which will automatically download a specific tag of the library and make it available to the project. This requires adjusting the CI build image to include `git` CLI to fetch the content.

As an example of how the library can be used, this PR also introduces a registry which will be used to store all entities and their components. It also adds a simple `FactionComponent` to store the faction of an entity. Compared to the version available in earlier versions of the game (see e.g. [v0.1.3](https://github.com/Knoblauchpilze/bsgalone/releases/tag/v0.1.3), this system does not rely on an abstract `IComponent` class and keesp the components as thin as possible. It should also allow to separate in a cleaner way what belongs to systems from what belongs to components.

# Tests

Simple unit tests for the entity registry show how to iterate over entities/components.

# Future work

This PR provides the foundations on which the game logic will be built.
